### PR TITLE
Fix date input cannot switch month/year in dropdown picker

### DIFF
--- a/src/scripts/DateInput.js
+++ b/src/scripts/DateInput.js
@@ -213,7 +213,9 @@ export default class DateInput extends Component {
       typeof dateValue !== 'undefined' && mvalue.isValid() ?
         mvalue.format(this.getInputValueFormat()) :
         undefined;
-    const dropdown = this.renderDropdown(mvalue.format('YYYY-MM-DD'));
+    const dropdown = this.renderDropdown(
+      mvalue.isValid() ? mvalue.format('YYYY-MM-DD') : undefined
+    );
     const formElemProps = { id, totalCols, cols, label, required, error, dropdown };
     return (
       <FormElement { ...formElemProps }>


### PR DESCRIPTION
When initial value is not set to DateInput, the rendered dropdown doesn't have default focus, and cannot move to target month/year in datepicker control.