### PR TITLE
Fix eslint to include unresolved module check

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,14 +8,9 @@
     "react/no-multi-comp": 0,
     "react/jsx-no-bind": 0
   },
-  "settings": {
-    "import/ignore": [
-      "react-lightning-design-system"
-    ]
-  },
   "parserOptions": {
     "ecmaFeatures": {
-        "experimentalObjectRestSpread": true
+      "experimentalObjectRestSpread": true
     }
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,11 @@
     "react/no-multi-comp": 0,
     "react/jsx-no-bind": 0
   },
+  "settings": {
+    "import/ignore": [
+      "react-lightning-design-system"
+    ]
+  },
   "parserOptions": {
     "ecmaFeatures": {
         "experimentalObjectRestSpread": true

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,8 +6,7 @@
     "no-nested-ternary": 0,
     "react/jsx-curly-spacing": 0,
     "react/no-multi-comp": 0,
-    "react/jsx-no-bind": 0,
-    "import/no-unresolved": 0
+    "react/jsx-no-bind": 0
   },
   "parserOptions": {
     "ecmaFeatures": {

--- a/examples/.eslintrc
+++ b/examples/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "no-alert": 0,
+    "import/no-unresolved": 0
+  }
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint": "npm run lint:src && npm run lint:examples && npm run lint:test",
     "lint:src": "eslint --ext .js src/scripts/**",
     "lint:examples": "eslint --ext .js examples/client/**",
-    "lint:test": "eslint --ext .js test/**",
+    "lint:test": "eslint --ext .js --rule \"import/no-unresolved\":0 test/**",
     "build": "babel -d lib/ src/"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lightning-design-system",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Salesforce Lightning Design System components built with React",
   "main": "lib/scripts/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint": "npm run lint:src && npm run lint:examples && npm run lint:test",
     "lint:src": "eslint --ext .js src/scripts/**",
     "lint:examples": "eslint --ext .js examples/client/**",
-    "lint:test": "eslint --ext .js --rule \"import/no-unresolved\":0 test/**",
+    "lint:test": "eslint --ext .js test/**",
     "build": "babel -d lib/ src/"
   },
   "files": [

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -4,6 +4,7 @@
   },
   "rules": {
     "no-undef": 0,
-    "no-unused-expressions": 0
+    "no-unused-expressions": 0,
+    "import/no-unresolved": 0
   }
 }


### PR DESCRIPTION
To prevent the filename case error in CI (which might not be easily notified in local MacOS environment), include lint check for unresolved files importing