### PR TITLE
Fix lookup icon align default to right

### DIFF
--- a/src/scripts/Lookup.js
+++ b/src/scripts/Lookup.js
@@ -179,7 +179,7 @@ class LookupSearch extends Component {
   }
 
   renderSearchInput(props) {
-    const { className, hidden, searchText, iconAlign = 'left' } = props;
+    const { className, hidden, searchText, iconAlign = 'right' } = props;
     const searchInputClassNames = classnames(
       'slds-grid',
       'slds-input-has-icon',
@@ -272,7 +272,7 @@ LookupSearch.propTypes = {
     })
   ),
   targetScope: PropTypes.any,
-  iconAlign: PropTypes.arrayOf(ICON_ALIGNS),
+  iconAlign: PropTypes.oneOf(ICON_ALIGNS),
   onKeyDown: PropTypes.func,
   onBlur: PropTypes.func,
   onChange: PropTypes.func,


### PR DESCRIPTION
The lookup search icon comes to left when no `iconAlign` prop is specified - which was not the default previously. Reset to right by default.