### PR TITLE
prevent warning when using DropdownButton iconSize

### DIFF
--- a/src/scripts/Button.js
+++ b/src/scripts/Button.js
@@ -28,7 +28,7 @@ export default class Button extends Component {
 
   render() {
     const {
-      className, type, size, icon, iconAlign, iconMore, selected, alt, label, loading,
+      className, type, size, icon, iconAlign, iconSize, iconMore, selected, alt, label, loading,
       htmlType = 'button', children, ...props,
     } = this.props;
     const typeClassName = type ? `slds-button--${type}` : null;


### PR DESCRIPTION
'unknown prop' warning caused by passing iconSize to button child tag