### PR TITLE
Remove timeouts from pickselect

### DIFF
--- a/src/scripts/DropdownMenu.js
+++ b/src/scripts/DropdownMenu.js
@@ -33,6 +33,12 @@ export class DropdownMenuItem extends Component {
     }
   }
 
+  onMouseDown(e) {
+    if (this.props.onMouseDown) {
+      this.props.onMouseDown(e);
+    }
+  }
+
   onFocus(e) {
     if (this.props.onFocus) {
       this.props.onFocus(e);
@@ -59,6 +65,7 @@ export class DropdownMenuItem extends Component {
           onClick={ disabled ? null : onClick }
           onKeyDown={ disabled ? null : this.onKeyDown.bind(this) }
           onBlur={ disabled ? null : this.onBlur.bind(this) }
+          onMouseDown={ disabled ? null : this.onMouseDown.bind(this) }
           onFocus={ disabled ? null : this.onFocus.bind(this) }
           { ...props }
         >
@@ -83,6 +90,7 @@ DropdownMenuItem.propTypes = {
   selected: PropTypes.bool,
   onClick: PropTypes.func,
   onBlur: PropTypes.func,
+  onMouseDown: PropTypes.func,
   onFocus: PropTypes.func,
   children: PropTypes.node,
 };
@@ -92,16 +100,32 @@ export const MenuItem = DropdownMenuItem;
 
 
 export default class DropdownMenu extends Component {
+
+  constructor(){
+    super();
+    this.itemMouseDown = false;
+  }
+
   onMenuItemBlur(e) {
     if (this.props.onBlur) {
       this.props.onBlur(e);
     }
+    if(this.props.onComponentBlur){
+      if(!this.itemMouseDown){
+        this.props.onComponentBlur(e);
+      }
+    }
+    this.itemMouseDown = false;
   }
 
   onMenuItemFocus(e) {
     if (this.props.onFocus) {
       this.props.onFocus(e);
     }
+  }
+
+  onMenuItemMouseDown(e){
+    this.itemMouseDown = true;
   }
 
   onKeyDown(e) {
@@ -128,10 +152,14 @@ export default class DropdownMenu extends Component {
       if (onBlur) { onBlur(e); }
       this.onMenuItemBlur(e);
     };
+    const onMenuItemMouseDown = (e) => {
+      this.onMenuItemMouseDown(e);
+    };
     return React.cloneElement(menuItem, {
       onClick: onMenuItemClick,
       onBlur: onMenuItemBlur,
       onFocus: onMenuItemFocus,
+      onMouseDown: onMenuItemMouseDown,
     });
   }
 
@@ -184,6 +212,7 @@ DropdownMenu.propTypes = {
   onMenuItemClick: PropTypes.func,
   onMenuClose: PropTypes.func,
   onBlur: PropTypes.func,
+  onComponentBlur: PropTypes.func,
   onFocus: PropTypes.func,
   children: PropTypes.node,
   dropdownMenuRef: PropTypes.func,

--- a/src/scripts/DropdownMenu.js
+++ b/src/scripts/DropdownMenu.js
@@ -19,6 +19,7 @@ export class DropdownMenuItem extends Component {
       while (itemEl) {
         const anchorEl = itemEl.querySelector('.react-slds-menuitem[tabIndex]');
         if (anchorEl && !anchorEl.disabled) {
+          this.onWillFocus();
           anchorEl.focus();
           return;
         }
@@ -34,8 +35,12 @@ export class DropdownMenuItem extends Component {
   }
 
   onMouseDown(e) {
-    if (this.props.onMouseDown) {
-      this.props.onMouseDown(e);
+    this.onWillFocus(e);
+  }
+
+  onWillFocus(e){
+    if (this.props.onWillFocus) {
+      this.props.onWillFocus(e);
     }
   }
 
@@ -55,6 +60,7 @@ export class DropdownMenuItem extends Component {
       { 'slds-is-selected': selected },
       className
     );
+    const { onWillFocus, ...pprops } = props;
     return (
       <li className={ menuItemClass } disabled={ disabled }>
         <a
@@ -67,7 +73,7 @@ export class DropdownMenuItem extends Component {
           onBlur={ disabled ? null : this.onBlur.bind(this) }
           onMouseDown={ disabled ? null : this.onMouseDown.bind(this) }
           onFocus={ disabled ? null : this.onFocus.bind(this) }
-          { ...props }
+          { ...pprops }
         >
           <p className='slds-truncate'>
             { icon ? <Icon icon={ icon } size='x-small' align='left' /> : null }
@@ -90,7 +96,7 @@ DropdownMenuItem.propTypes = {
   selected: PropTypes.bool,
   onClick: PropTypes.func,
   onBlur: PropTypes.func,
-  onMouseDown: PropTypes.func,
+  onWillFocus: PropTypes.func,
   onFocus: PropTypes.func,
   children: PropTypes.node,
 };
@@ -103,7 +109,7 @@ export default class DropdownMenu extends Component {
 
   constructor(){
     super();
-    this.itemMouseDown = false;
+    this.focusInComponent = false;
   }
 
   onMenuItemBlur(e) {
@@ -111,11 +117,11 @@ export default class DropdownMenu extends Component {
       this.props.onBlur(e);
     }
     if(this.props.onComponentBlur){
-      if(!this.itemMouseDown){
+      if(!this.focusInComponent){
         this.props.onComponentBlur(e);
       }
     }
-    this.itemMouseDown = false;
+    this.focusInComponent = false;
   }
 
   onMenuItemFocus(e) {
@@ -124,8 +130,8 @@ export default class DropdownMenu extends Component {
     }
   }
 
-  onMenuItemMouseDown(e){
-    this.itemMouseDown = true;
+  onMenuItemWillFocus(e){
+    this.focusInComponent = true;
   }
 
   onKeyDown(e) {
@@ -152,14 +158,14 @@ export default class DropdownMenu extends Component {
       if (onBlur) { onBlur(e); }
       this.onMenuItemBlur(e);
     };
-    const onMenuItemMouseDown = (e) => {
-      this.onMenuItemMouseDown(e);
+    const onMenuItemWillFocus = (e) => {
+      this.onMenuItemWillFocus(e);
     };
     return React.cloneElement(menuItem, {
       onClick: onMenuItemClick,
       onBlur: onMenuItemBlur,
       onFocus: onMenuItemFocus,
-      onMouseDown: onMenuItemMouseDown,
+      onWillFocus: onMenuItemWillFocus,
     });
   }
 

--- a/src/scripts/Picklist.js
+++ b/src/scripts/Picklist.js
@@ -38,16 +38,14 @@ export default class Picklist extends Component {
     if (this.props.onSelect) {
       this.props.onSelect(item);
     }
-    setTimeout(() => {
-      this.setState({ opened: false });
-      if (this.props.onComplete) {
-        this.props.onComplete();
-      }
-      const picklistButtonEl = this.picklistButton;
-      if (picklistButtonEl) {
-        picklistButtonEl.focus();
-      }
-    }, 200);
+    this.setState({ opened: false });
+    if (this.props.onComplete) {
+      this.props.onComplete();
+    }
+    const picklistButtonEl = this.picklistButton;
+    if (picklistButtonEl) {
+      picklistButtonEl.focus();
+    }
     e.preventDefault();
     e.stopPropagation();
   }
@@ -59,17 +57,13 @@ export default class Picklist extends Component {
   }
 
   onBlur() {
-    setTimeout(() => {
-      if (!this.isFocusedInComponent()) {
-        this.setState({ opened: false });
-        if (this.props.onBlur) {
-          this.props.onBlur();
-        }
-        if (this.props.onComplete) {
-          this.props.onComplete();
-        }
-      }
-    }, 10);
+    this.setState({ opened: false });
+    if (this.props.onBlur) {
+      this.props.onBlur();
+    }
+    if (this.props.onComplete) {
+      this.props.onComplete();
+    }
   }
 
   onKeydown(e) {
@@ -148,7 +142,6 @@ export default class Picklist extends Component {
           className='slds-picklist__label'
           type='neutral'
           onClick={ this.onClick.bind(this) }
-          onBlur={ this.onBlur.bind(this) }
           onKeyDown={ this.onKeydown.bind(this) }
         >
           <span className='slds-truncate'>
@@ -169,6 +162,7 @@ export default class Picklist extends Component {
           size={ menuSize }
           onMenuItemClick={ this.onPicklistItemClick.bind(this) }
           onMenuClose={ this.onPicklistClose.bind(this) }
+          onComponentBlur={ this.onBlur.bind(this) }
         >
           { React.Children.map(children, this.renderPicklistItem.bind(this)) }
         </DropdownMenu> :


### PR DESCRIPTION
Not sure if this is an issue for other people, but having calls to `setState(...)` inside of timeouts in the Pickselect component would trigger the typical error:

> Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the undefined component.

The timeouts were required to know whether clicks were happening inside the component or outside, for hiding the dropdown menu on blur.

To solve this it uses an extra event on `DropdownMenuItem` "onWillFocus" which indicates whether another element is going to be focused. This way the `DropdownMenu` knows before receiving the blur event.

This works well for us so I figured it would be nice to contribute it back.