### PR TITLE
Fix version of lint libs to prevent auto-update errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
   "dependencies": {
     "babel-runtime": "^6.6.1",
     "classnames": "^2.2.5",
+    "keycoder": "^1.1.1",
     "moment": "^2.13.0",
     "svg4everybody": "^2.0.3",
-    "uuid": "^2.0.2",
-    "keycoder": "^1.1.1"
+    "uuid": "^2.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",
@@ -56,11 +56,11 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "enzyme": "^2.3.0",
-    "eslint": "^3.4.0",
-    "eslint-config-airbnb": "^12.0.0",
-    "eslint-plugin-import": "^1.16.0",
-    "eslint-plugin-jsx-a11y": "^2.2.1",
-    "eslint-plugin-react": "^6.2.0",
+    "eslint": "3.8.1",
+    "eslint-config-airbnb": "12.0.0",
+    "eslint-plugin-import": "1.16.0",
+    "eslint-plugin-jsx-a11y": "2.2.3",
+    "eslint-plugin-react": "6.4.1",
     "jest": "^16.0.2",
     "power-assert": "^1.4.1",
     "react": "^15.3.0",


### PR DESCRIPTION
Fix the version of dependent lint libs in order to prevent errors when the dependent eslint libs are updated.