### PR TITLE
Fix onSelect will be called when the lookup search has selected

### DIFF
--- a/src/scripts/Lookup.js
+++ b/src/scripts/Lookup.js
@@ -568,6 +568,13 @@ export default class Lookup extends Component {
       className
     );
     const formElemProps = { id, totalCols, cols, label, required, error, dropdown };
+    /* eslint-disable no-unused-vars */
+    const {
+      defaultSelected, defaultOpened, defaultSearchText, defaultTargetScope,
+      onSelect, onBlur, onScopeChange, onScopeMenuClick, onSearchTextChange, onLookupRequest,
+      ...searchProps
+    } = props;
+    /* eslint-enable no-unused-vars */
     return (
       <FormElement formElementRef={ node => (this.node = node) } { ...formElemProps }>
         <div
@@ -585,7 +592,7 @@ export default class Lookup extends Component {
                 onResetSelection={ this.onResetSelection.bind(this) }
               /> :
                 <LookupSearch
-                  { ...props }
+                  { ...searchProps }
                   id={ id }
                   lookupSearchRef={ node => (this.search = node) }
                   searchText={ searchText }


### PR DESCRIPTION
As the `onSelect` property handler to lookup component is passed down to lookup search component and its `input` html element, the select event handler will be fired unexpectedly.

Exclude unused props when passing down to child component.

Fixes #131 .