### PR TITLE
Revert the dateinput format handlings

### DIFF
--- a/src/scripts/DateInput.js
+++ b/src/scripts/DateInput.js
@@ -27,8 +27,7 @@ export default class DateInput extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     if (this.props.onValueChange && prevState.value !== this.state.value) {
-      const value = moment(this.state.value, 'YYYY-MM-DD').format(this.props.dateFormat);
-      this.props.onValueChange(value, prevState.value);
+      this.props.onValueChange(this.state.value, prevState.value);
     }
   }
 

--- a/src/scripts/DateInput.js
+++ b/src/scripts/DateInput.js
@@ -224,7 +224,11 @@ export default class DateInput extends Component {
       typeof this.state.inputValue !== 'undefined' ? this.state.inputValue :
         typeof dateValue !== 'undefined' && mvalue.isValid() ? mvalue.format(dateFormat) :
           undefined;
-    const dropdown = this.renderDropdown(dateValue, minDate, maxDate);
+    const dropdown = this.renderDropdown(
+      mvalue.isValid() ? mvalue.format('YYYY-MM-DD') : undefined,
+      minDate,
+      maxDate
+    );
     const formElemProps = { id, totalCols, cols, label, required, error, dropdown };
     delete props.dateFormat;
     delete props.defaultOpened;

--- a/src/scripts/DateInput.js
+++ b/src/scripts/DateInput.js
@@ -221,8 +221,10 @@ export default class DateInput extends Component {
           defaultValue;
     const mvalue = moment(dateValue, this.getValueFormat());
     const inputValue =
-      typeof this.state.inputValue !== 'undefined' ? this.state.inputValue :
-        typeof dateValue !== 'undefined' && mvalue.isValid() ? mvalue.format(dateFormat) :
+      typeof this.state.inputValue !== 'undefined' ?
+        this.state.inputValue :
+      typeof dateValue !== 'undefined' && mvalue.isValid() ?
+        mvalue.format(this.getInputValueFormat()) :
           undefined;
     const dropdown = this.renderDropdown(
       mvalue.isValid() ? mvalue.format('YYYY-MM-DD') : undefined,

--- a/src/scripts/DateInput.js
+++ b/src/scripts/DateInput.js
@@ -132,7 +132,7 @@ export default class DateInput extends Component {
     if (!inputValue) {
       value = '';
     } else {
-      value = moment(inputValue, this.props.dateFormat);
+      value = moment(inputValue, this.getInputValueFormat());
       if (value.isValid()) {
         value = value.format(this.getValueFormat());
       } else {
@@ -211,7 +211,7 @@ export default class DateInput extends Component {
     const id = this.props.id || this.state.id;
     const {
       totalCols, cols, label, required, error,
-      defaultValue, value, dateFormat, menuAlign,
+      defaultValue, value, menuAlign,
       minDate, maxDate,
       ...props
     } = this.props;
@@ -273,7 +273,6 @@ DateInput.propTypes = {
 };
 
 DateInput.defaultProps = {
-  dateFormat: 'L',
   menuAlign: 'left',
 };
 


### PR DESCRIPTION
The previous commits bring corruption in dateformat handling in DateInput component.
- Should accept raw ISO8601-based date/datetime format in value/defaultValue.
- Should emit raw ISO8601-based date/datetime format in `onValueChange`.
- The `dateFormat` prop default should not be set in defaultProps because it will change when `includeTime` prop is set. Use `getInputValueFormat()`.

Fixes #114.
