### PR TITLE
fix react-hot-loader for webpack dev server

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -27,7 +27,7 @@
     "babel-loader": "^6.2.4",
     "gh-pages": "^0.11.0",
     "html-webpack-plugin": "^2.22.0",
-    "react-hot-loader": "^1.3.0",
+    "react-hot-loader": "^3.0.0-beta.6",
     "webpack": "^1.13.1",
     "webpack-dev-server": "^1.14.1"
   }

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -63,7 +63,7 @@ const config = {
       {
         test: /\.js$/,
         loaders: [
-          'react-hot',
+          'react-hot-loader/webpack',
           'babel-loader',
         ],
         exclude: /node_modules/,


### PR DESCRIPTION
fix for `npm run start:dev` command in `examples` folder