### PR TITLE
Fix DateInput onBlur/onComplete event is fired when the focus is still inside of the component

### DIFF
--- a/src/scripts/DateInput.js
+++ b/src/scripts/DateInput.js
@@ -180,6 +180,7 @@ export default class DateInput extends Component {
           icon='event'
           className='slds-input__icon'
           style={ { cursor: 'pointer' } }
+          tabIndex={ -1 }
           onClick={ this.onDateIconClick }
         />
       </div>

--- a/src/scripts/Datepicker.js
+++ b/src/scripts/Datepicker.js
@@ -299,6 +299,7 @@ export default class Datepicker extends Component {
       <div
         className={ datepickerClassNames }
         ref={node => (this.node = node)}
+        tabIndex={ -1 }
         aria-hidden={ false }
         onBlur={ this.onBlur }
         onKeyDown={ this.onKeyDown }


### PR DESCRIPTION
Due to the calendar icon of DateInput which has no tabIndex right now, clicking calendar icon will fire the onBlur and onComplete event because it loses the cursor focus from the component. This is also for datepicker container element.

Add proper tabIndex attribute to these element to judge the blur event correctly.