### PR TITLE
Fix style of dropdown menu in horizontal form

### DIFF
--- a/src/scripts/FormElement.js
+++ b/src/scripts/FormElement.js
@@ -24,7 +24,7 @@ export default class FormElement extends React.Component {
       ],
       [
         '.react-slds-dropdown-control-wrapper > .slds-form-element__control',
-        '{ position: relative; padding-top: 0.1px; margin-top: -0.1px }',
+        '{ position: relative; padding-top: 0.1px; margin-top: -0.1px; vertical-align: top; }',
       ],
       [
         '.react-slds-dropdown-form-element',


### PR DESCRIPTION
In horizontal form, the dropdown menu is rendered with a wide space between input control and menu.

<img width="302" alt="mashmatrix_github_io_react-lightning-design-system___form" src="https://cloud.githubusercontent.com/assets/23387/21036376/c98e003a-be08-11e6-8241-061158a0ec28.png">
