### PR TITLE
Remove es6 array.prototype methods

### DIFF
--- a/src/scripts/DropdownMenu.js
+++ b/src/scripts/DropdownMenu.js
@@ -184,7 +184,7 @@ export default class DropdownMenu extends Component {
         { header ? <MenuHeader>{ header }</MenuHeader> : null }
         <ul className='slds-dropdown__list' role='menu'>
           { React.Children.map(children, item => (
-            [MenuItem, PicklistItem].includes(item.type) ? this.renderMenuItem(item) : item
+            item.type === MenuItem || item.type === PicklistItem ? this.renderMenuItem(item) : item
           )) }
         </ul>
       </div>


### PR DESCRIPTION
As the transform-runtime cannot cover the instance methods conversion,
these prototype methods will require the library users to load polyfills implicityly.

Fixes #168