### PR TITLE
Firefox doesn’t display label value’s for Select Option

### DIFF
--- a/.storybook/__storyshots__/Datepicker.shot
+++ b/.storybook/__storyshots__/Datepicker.shot
@@ -73,37 +73,59 @@ exports[`Controlled with knobs`] = `
             value={2017}>
             <option
               label={2012}
-              value={2012} />
+              value={2012}>
+              2012
+            </option>
             <option
               label={2013}
-              value={2013} />
+              value={2013}>
+              2013
+            </option>
             <option
               label={2014}
-              value={2014} />
+              value={2014}>
+              2014
+            </option>
             <option
               label={2015}
-              value={2015} />
+              value={2015}>
+              2015
+            </option>
             <option
               label={2016}
-              value={2016} />
+              value={2016}>
+              2016
+            </option>
             <option
               label={2017}
-              value={2017} />
+              value={2017}>
+              2017
+            </option>
             <option
               label={2018}
-              value={2018} />
+              value={2018}>
+              2018
+            </option>
             <option
               label={2019}
-              value={2019} />
+              value={2019}>
+              2019
+            </option>
             <option
               label={2020}
-              value={2020} />
+              value={2020}>
+              2020
+            </option>
             <option
               label={2021}
-              value={2021} />
+              value={2021}>
+              2021
+            </option>
             <option
               label={2022}
-              value={2022} />
+              value={2022}>
+              2022
+            </option>
           </select>
         </div>
       </div>
@@ -1332,37 +1354,59 @@ exports[`Default`] = `
             value={2016}>
             <option
               label={2011}
-              value={2011} />
+              value={2011}>
+              2011
+            </option>
             <option
               label={2012}
-              value={2012} />
+              value={2012}>
+              2012
+            </option>
             <option
               label={2013}
-              value={2013} />
+              value={2013}>
+              2013
+            </option>
             <option
               label={2014}
-              value={2014} />
+              value={2014}>
+              2014
+            </option>
             <option
               label={2015}
-              value={2015} />
+              value={2015}>
+              2015
+            </option>
             <option
               label={2016}
-              value={2016} />
+              value={2016}>
+              2016
+            </option>
             <option
               label={2017}
-              value={2017} />
+              value={2017}>
+              2017
+            </option>
             <option
               label={2018}
-              value={2018} />
+              value={2018}>
+              2018
+            </option>
             <option
               label={2019}
-              value={2019} />
+              value={2019}>
+              2019
+            </option>
             <option
               label={2020}
-              value={2020} />
+              value={2020}>
+              2020
+            </option>
             <option
               label={2021}
-              value={2021} />
+              value={2021}>
+              2021
+            </option>
           </select>
         </div>
       </div>
@@ -2534,37 +2578,59 @@ exports[`Extension Rendering`] = `
             value={2016}>
             <option
               label={2011}
-              value={2011} />
+              value={2011}>
+              2011
+            </option>
             <option
               label={2012}
-              value={2012} />
+              value={2012}>
+              2012
+            </option>
             <option
               label={2013}
-              value={2013} />
+              value={2013}>
+              2013
+            </option>
             <option
               label={2014}
-              value={2014} />
+              value={2014}>
+              2014
+            </option>
             <option
               label={2015}
-              value={2015} />
+              value={2015}>
+              2015
+            </option>
             <option
               label={2016}
-              value={2016} />
+              value={2016}>
+              2016
+            </option>
             <option
               label={2017}
-              value={2017} />
+              value={2017}>
+              2017
+            </option>
             <option
               label={2018}
-              value={2018} />
+              value={2018}>
+              2018
+            </option>
             <option
               label={2019}
-              value={2019} />
+              value={2019}>
+              2019
+            </option>
             <option
               label={2020}
-              value={2020} />
+              value={2020}>
+              2020
+            </option>
             <option
               label={2021}
-              value={2021} />
+              value={2021}>
+              2021
+            </option>
           </select>
         </div>
       </div>

--- a/.storybook/__storyshots__/Select.shot
+++ b/.storybook/__storyshots__/Select.shot
@@ -25,13 +25,19 @@ exports[`Controlled with knobs`] = `
           value={undefined}>
           <option
             label="Option One"
-            value="1" />
+            value="1">
+            Option One
+          </option>
           <option
             label="Option Two"
-            value="2" />
+            value="2">
+            Option Two
+          </option>
           <option
             label="Option Three"
-            value="3" />
+            value="3">
+            Option Three
+          </option>
         </select>
       </div>
     </div>
@@ -862,13 +868,19 @@ exports[`Default`] = `
           onChange={[Function]}>
           <option
             label="Option One"
-            value="1" />
+            value="1">
+            Option One
+          </option>
           <option
             label="Option Two"
-            value="2" />
+            value="2">
+            Option Two
+          </option>
           <option
             label="Option Three"
-            value="3" />
+            value="3">
+            Option Three
+          </option>
         </select>
       </div>
     </div>
@@ -1579,13 +1591,19 @@ exports[`Disabled`] = `
           onChange={[Function]}>
           <option
             label="Option One"
-            value="1" />
+            value="1">
+            Option One
+          </option>
           <option
             label="Option Two"
-            value="2" />
+            value="2">
+            Option Two
+          </option>
           <option
             label="Option Three"
-            value="3" />
+            value="3">
+            Option Three
+          </option>
         </select>
       </div>
     </div>
@@ -2318,13 +2336,19 @@ exports[`Error`] = `
           onChange={[Function]}>
           <option
             label="Option One"
-            value="1" />
+            value="1">
+            Option One
+          </option>
           <option
             label="Option Two"
-            value="2" />
+            value="2">
+            Option Two
+          </option>
           <option
             label="Option Three"
-            value="3" />
+            value="3">
+            Option Three
+          </option>
         </select>
         <span
           className="slds-form-element__help">
@@ -3088,13 +3112,19 @@ exports[`Required`] = `
           onChange={[Function]}>
           <option
             label="Option One"
-            value="1" />
+            value="1">
+            Option One
+          </option>
           <option
             label="Option Two"
-            value="2" />
+            value="2">
+            Option Two
+          </option>
           <option
             label="Option Three"
-            value="3" />
+            value="3">
+            Option Three
+          </option>
         </select>
       </div>
     </div>

--- a/README.md
+++ b/README.md
@@ -44,3 +44,10 @@ To run stories and get component examples, follow these steps:
 1. run ```npm install```
 2. run ```npm run storybook```
 3. Find the stories running on [localhost:9001](http://localhost:9001).
+
+## Snapshot testing in react storybook
+
+This repo ships with story snapshots to examine differences in rendering as a result of changes to source code.
+
+To identify render differences run ```npm run test:storyshots```.  If  all changes are intentional run ```npm run test:storyshots -- -u```.  To learn about other run options including *interactive mode*, read
+[Snapshot Testing in React Storybook](https://voice.kadira.io/snapshot-testing-in-react-storybook-43b3b71cec4f)

--- a/src/scripts/Select.js
+++ b/src/scripts/Select.js
@@ -58,6 +58,6 @@ Select.propTypes = {
 
 Select.isFormElement = true;
 
-export const Option = props => (
-  <option { ...props } />
-);
+export const Option = (props) => {
+  return props.children ? <option {...props} /> : <option {...props}>{props.label}</option>;
+};


### PR DESCRIPTION
Firefox doesn’t display label value’s for Select Option. https://screencast.com/t/7wgClTiqmQ.  Update Option to use label when props.children not provided.