### PR TITLE
Support meta information displaying in lookup candidates

### DIFF
--- a/.storybook/__storyshots__/Form.shot
+++ b/.storybook/__storyshots__/Form.shot
@@ -416,60 +416,87 @@ exports[`Compound Form`] = `
                           className="slds-lookup__list"
                           role="presentation">
                           <li
-                            className="slds-lookup__item">
+                            role="presentation">
                             <a
-                              className="slds-truncate react-slds-candidate"
+                              className="slds-lookup__item-action react-slds-candidate"
                               onBlur={[Function]}
                               onClick={[Function]}
                               onKeyDown={[Function]}
                               role="option"
                               tabIndex={-1}>
-                              <svg
-                                aria-hidden={true}
-                                className="slds-icon slds-icon--small slds-icon-standard-account"
-                                style={undefined}>
-                                <use
-                                  xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                              </svg>
-                              Account
+                              <span
+                                className="slds-media slds-media--center slds-truncate">
+                                <svg
+                                  aria-hidden={true}
+                                  className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                                  style={undefined}>
+                                  <use
+                                    xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                                </svg>
+                                <div
+                                  className="slds-media__body slds-truncate">
+                                  <span
+                                    className="slds-lookup__result-text slds-truncate">
+                                    Account
+                                  </span>
+                                </div>
+                              </span>
                             </a>
                           </li>
                           <li
-                            className="slds-lookup__item">
+                            role="presentation">
                             <a
-                              className="slds-truncate react-slds-candidate"
+                              className="slds-lookup__item-action react-slds-candidate"
                               onBlur={[Function]}
                               onClick={[Function]}
                               onKeyDown={[Function]}
                               role="option"
                               tabIndex={-1}>
-                              <svg
-                                aria-hidden={true}
-                                className="slds-icon slds-icon--small slds-icon-standard-contact"
-                                style={undefined}>
-                                <use
-                                  xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#contact" />
-                              </svg>
-                              Contact
+                              <span
+                                className="slds-media slds-media--center slds-truncate">
+                                <svg
+                                  aria-hidden={true}
+                                  className="slds-icon slds-icon--small slds-icon-standard-contact slds-media__figure"
+                                  style={undefined}>
+                                  <use
+                                    xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#contact" />
+                                </svg>
+                                <div
+                                  className="slds-media__body slds-truncate">
+                                  <span
+                                    className="slds-lookup__result-text slds-truncate">
+                                    Contact
+                                  </span>
+                                </div>
+                              </span>
                             </a>
                           </li>
                           <li
-                            className="slds-lookup__item">
+                            role="presentation">
                             <a
-                              className="slds-truncate react-slds-candidate"
+                              className="slds-lookup__item-action react-slds-candidate"
                               onBlur={[Function]}
                               onClick={[Function]}
                               onKeyDown={[Function]}
                               role="option"
                               tabIndex={-1}>
-                              <svg
-                                aria-hidden={true}
-                                className="slds-icon slds-icon--small slds-icon-standard-opportunity"
-                                style={undefined}>
-                                <use
-                                  xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
-                              </svg>
-                              Opportunity
+                              <span
+                                className="slds-media slds-media--center slds-truncate">
+                                <svg
+                                  aria-hidden={true}
+                                  className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                                  style={undefined}>
+                                  <use
+                                    xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
+                                </svg>
+                                <div
+                                  className="slds-media__body slds-truncate">
+                                  <span
+                                    className="slds-lookup__result-text slds-truncate">
+                                    Opportunity
+                                  </span>
+                                </div>
+                              </span>
                             </a>
                           </li>
                         </ul>
@@ -7530,60 +7557,87 @@ exports[`Horizontal Form`] = `
                     className="slds-lookup__list"
                     role="presentation">
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Account
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Account
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-contact"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#contact" />
-                        </svg>
-                        Contact
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-contact slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#contact" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Contact
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-opportunity"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
-                        </svg>
-                        Opportunity
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Opportunity
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                   </ul>
@@ -13459,60 +13513,87 @@ exports[`Stacked Form`] = `
                     className="slds-lookup__list"
                     role="presentation">
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Account
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Account
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-contact"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#contact" />
-                        </svg>
-                        Contact
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-contact slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#contact" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Contact
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-opportunity"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
-                        </svg>
-                        Opportunity
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Opportunity
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                   </ul>

--- a/.storybook/__storyshots__/Lookup.shot
+++ b/.storybook/__storyshots__/Lookup.shot
@@ -124,934 +124,1571 @@ exports[`Active`] = `
                     className="slds-lookup__list"
                     role="presentation">
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Apple Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Apple Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Alphabet Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Alphabet Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Microsoft Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Microsoft Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Facebook, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Facebook, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Intel Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Intel Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Oracle Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Oracle Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Cisco Systems, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Cisco Systems, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        International Business Machines Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              International Business Machines Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        QUALCOMM Incorporated
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              QUALCOMM Incorporated
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Texas Instruments Incorporated
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Texas Instruments Incorporated
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Salesforce.com Inc
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Salesforce.com Inc
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        EMC Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              EMC Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Adobe Systems Incorporated
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Adobe Systems Incorporated
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Automatic Data Processing, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Automatic Data Processing, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Cognizant Technology Solutions Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Cognizant Technology Solutions Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Broadcom Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Broadcom Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Illinois Tool Works Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Illinois Tool Works Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Yahoo! Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Yahoo! Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        LinkedIn Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              LinkedIn Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Activision Blizzard, Inc
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Activision Blizzard, Inc
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Intuit Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Intuit Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Vmware, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Vmware, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Fiserv, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Fiserv, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Applied Materials, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Applied Materials, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Cerner Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Cerner Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Electronic Arts Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Electronic Arts Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        HP Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              HP Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Omnicom Group Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Omnicom Group Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        NVIDIA Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              NVIDIA Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Analog Devices, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Analog Devices, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        SanDisk Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              SanDisk Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Micron Technology, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Micron Technology, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Red Hat, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Red Hat, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Palo Alto Networks, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Palo Alto Networks, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Workday, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Workday, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Symantec Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Symantec Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Western Digital Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Western Digital Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Skyworks Solutions, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Skyworks Solutions, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        ServiceNow, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              ServiceNow, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Autodesk, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Autodesk, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Verisk Analytics, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Verisk Analytics, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        CA Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              CA Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Lam Research Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Lam Research Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Motorola Solutions, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Motorola Solutions, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Xilinx, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Xilinx, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        TripAdvisor, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              TripAdvisor, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Citrix Systems, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Citrix Systems, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Juniper Networks, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Juniper Networks, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Maxim Integrated Products, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Maxim Integrated Products, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                   </ul>
@@ -3781,934 +4418,1571 @@ exports[`Controlled with knobs`] = `
                   className="slds-lookup__list"
                   role="presentation">
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Apple Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Apple Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Alphabet Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Alphabet Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Microsoft Corporation
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Microsoft Corporation
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Facebook, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Facebook, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Intel Corporation
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Intel Corporation
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Oracle Corporation
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Oracle Corporation
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Cisco Systems, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Cisco Systems, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      International Business Machines Corporation
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            International Business Machines Corporation
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      QUALCOMM Incorporated
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            QUALCOMM Incorporated
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Texas Instruments Incorporated
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Texas Instruments Incorporated
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Salesforce.com Inc
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Salesforce.com Inc
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      EMC Corporation
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            EMC Corporation
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Adobe Systems Incorporated
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Adobe Systems Incorporated
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Automatic Data Processing, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Automatic Data Processing, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Cognizant Technology Solutions Corporation
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Cognizant Technology Solutions Corporation
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Broadcom Corporation
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Broadcom Corporation
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Illinois Tool Works Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Illinois Tool Works Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Yahoo! Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Yahoo! Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      LinkedIn Corporation
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            LinkedIn Corporation
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Activision Blizzard, Inc
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Activision Blizzard, Inc
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Intuit Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Intuit Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Vmware, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Vmware, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Fiserv, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Fiserv, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Applied Materials, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Applied Materials, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Cerner Corporation
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Cerner Corporation
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Electronic Arts Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Electronic Arts Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      HP Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            HP Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Omnicom Group Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Omnicom Group Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      NVIDIA Corporation
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            NVIDIA Corporation
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Analog Devices, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Analog Devices, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      SanDisk Corporation
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            SanDisk Corporation
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Micron Technology, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Micron Technology, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Red Hat, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Red Hat, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Palo Alto Networks, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Palo Alto Networks, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Workday, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Workday, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Symantec Corporation
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Symantec Corporation
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Western Digital Corporation
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Western Digital Corporation
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Skyworks Solutions, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Skyworks Solutions, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      ServiceNow, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            ServiceNow, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Autodesk, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Autodesk, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Verisk Analytics, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Verisk Analytics, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      CA Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            CA Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Lam Research Corporation
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Lam Research Corporation
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Motorola Solutions, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Motorola Solutions, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Xilinx, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Xilinx, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      TripAdvisor, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            TripAdvisor, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Citrix Systems, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Citrix Systems, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Juniper Networks, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Juniper Networks, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Maxim Integrated Products, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Maxim Integrated Products, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                 </ul>
@@ -9598,155 +10872,259 @@ exports[`Uncontrolled`] = `
                   className="slds-lookup__list"
                   role="presentation">
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Apple Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Apple Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Alphabet Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Alphabet Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Adobe Systems Incorporated
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Adobe Systems Incorporated
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Automatic Data Processing, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Automatic Data Processing, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Activision Blizzard, Inc
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Activision Blizzard, Inc
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Applied Materials, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Applied Materials, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Analog Devices, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Analog Devices, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                      </svg>
-                      Autodesk, Inc.
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Autodesk, Inc.
+                          </span>
+                          <span
+                            className="slds-lookup__result-meta slds-truncate">
+                            (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                 </ul>
@@ -10967,155 +12345,227 @@ exports[`Uncontrolled with Multi Scope`] = `
                   className="slds-lookup__list"
                   role="presentation">
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-opportunity"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
-                      </svg>
-                      Apple Inc. - New License
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Apple Inc. - New License
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-opportunity"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
-                      </svg>
-                      Alphabet Inc. - Professional Service
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Alphabet Inc. - Professional Service
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-opportunity"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
-                      </svg>
-                      Adobe Systems Incorporated - New License
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Adobe Systems Incorporated - New License
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-opportunity"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
-                      </svg>
-                      Automatic Data Processing, Inc. - Professional Service
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Automatic Data Processing, Inc. - Professional Service
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-opportunity"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
-                      </svg>
-                      Activision Blizzard, Inc - Hardware Renewal
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Activision Blizzard, Inc - Hardware Renewal
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-opportunity"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
-                      </svg>
-                      Applied Materials, Inc. - Hardware Renewal
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Applied Materials, Inc. - Hardware Renewal
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-opportunity"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
-                      </svg>
-                      Analog Devices, Inc. - Professional Service
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Analog Devices, Inc. - Professional Service
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                   <li
-                    className="slds-lookup__item">
+                    role="presentation">
                     <a
-                      className="slds-truncate react-slds-candidate"
+                      className="slds-lookup__item-action react-slds-candidate"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
                       tabIndex={-1}>
-                      <svg
-                        aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-opportunity"
-                        style={undefined}>
-                        <use
-                          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
-                      </svg>
-                      Autodesk, Inc. - Hardware Renewal
+                      <span
+                        className="slds-media slds-media--center slds-truncate">
+                        <svg
+                          aria-hidden={true}
+                          className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                          style={undefined}>
+                          <use
+                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
+                        </svg>
+                        <div
+                          className="slds-media__body slds-truncate">
+                          <span
+                            className="slds-lookup__result-text slds-truncate">
+                            Autodesk, Inc. - Hardware Renewal
+                          </span>
+                        </div>
+                      </span>
                     </a>
                   </li>
                 </ul>
@@ -12658,934 +14108,1571 @@ exports[`With list header/footer`] = `
                     className="slds-lookup__list"
                     role="presentation">
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Apple Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Apple Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Alphabet Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Alphabet Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Microsoft Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Microsoft Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Facebook, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Facebook, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Intel Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Intel Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Oracle Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Oracle Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Cisco Systems, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Cisco Systems, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        International Business Machines Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              International Business Machines Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        QUALCOMM Incorporated
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              QUALCOMM Incorporated
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Texas Instruments Incorporated
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Texas Instruments Incorporated
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Salesforce.com Inc
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Salesforce.com Inc
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        EMC Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              EMC Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Adobe Systems Incorporated
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Adobe Systems Incorporated
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Automatic Data Processing, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Automatic Data Processing, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Cognizant Technology Solutions Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Cognizant Technology Solutions Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Broadcom Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Broadcom Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Illinois Tool Works Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Illinois Tool Works Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Yahoo! Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Yahoo! Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        LinkedIn Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              LinkedIn Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Activision Blizzard, Inc
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Activision Blizzard, Inc
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Intuit Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Intuit Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Vmware, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Vmware, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Fiserv, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Fiserv, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Applied Materials, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Applied Materials, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Cerner Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Cerner Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Electronic Arts Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Electronic Arts Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        HP Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              HP Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Omnicom Group Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Omnicom Group Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        NVIDIA Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              NVIDIA Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Analog Devices, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Analog Devices, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        SanDisk Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              SanDisk Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Micron Technology, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Micron Technology, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Red Hat, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Red Hat, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Palo Alto Networks, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Palo Alto Networks, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Workday, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Workday, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Symantec Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Symantec Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Western Digital Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Western Digital Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Skyworks Solutions, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Skyworks Solutions, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        ServiceNow, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              ServiceNow, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Autodesk, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Autodesk, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Verisk Analytics, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Verisk Analytics, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        CA Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              CA Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Lam Research Corporation
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Lam Research Corporation
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Motorola Solutions, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Motorola Solutions, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Xilinx, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Xilinx, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        TripAdvisor, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              TripAdvisor, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Citrix Systems, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Citrix Systems, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Juniper Networks, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Juniper Networks, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                     <li
-                      className="slds-lookup__item">
+                      role="presentation">
                       <a
-                        className="slds-truncate react-slds-candidate"
+                        className="slds-lookup__item-action react-slds-candidate"
                         onBlur={[Function]}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="option"
                         tabIndex={-1}>
-                        <svg
-                          aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account"
-                          style={undefined}>
-                          <use
-                            xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                        </svg>
-                        Maxim Integrated Products, Inc.
+                        <span
+                          className="slds-media slds-media--center slds-truncate">
+                          <svg
+                            aria-hidden={true}
+                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            style={undefined}>
+                            <use
+                              xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                          </svg>
+                          <div
+                            className="slds-media__body slds-truncate">
+                            <span
+                              className="slds-lookup__result-text slds-truncate">
+                              Maxim Integrated Products, Inc.
+                            </span>
+                            <span
+                              className="slds-lookup__result-meta slds-truncate">
+                              (888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA
+                            </span>
+                          </div>
+                        </span>
                       </a>
                     </li>
                   </ul>

--- a/.storybook/__storyshots__/Modal.shot
+++ b/.storybook/__storyshots__/Modal.shot
@@ -3357,60 +3357,87 @@ exports[`Form elements`] = `
                             className="slds-lookup__list"
                             role="presentation">
                             <li
-                              className="slds-lookup__item">
+                              role="presentation">
                               <a
-                                className="slds-truncate react-slds-candidate"
+                                className="slds-lookup__item-action react-slds-candidate"
                                 onBlur={[Function]}
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
                                 role="option"
                                 tabIndex={-1}>
-                                <svg
-                                  aria-hidden={true}
-                                  className="slds-icon slds-icon--small slds-icon-standard-account"
-                                  style={undefined}>
-                                  <use
-                                    xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
-                                </svg>
-                                Account
+                                <span
+                                  className="slds-media slds-media--center slds-truncate">
+                                  <svg
+                                    aria-hidden={true}
+                                    className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                                    style={undefined}>
+                                    <use
+                                      xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
+                                  </svg>
+                                  <div
+                                    className="slds-media__body slds-truncate">
+                                    <span
+                                      className="slds-lookup__result-text slds-truncate">
+                                      Account
+                                    </span>
+                                  </div>
+                                </span>
                               </a>
                             </li>
                             <li
-                              className="slds-lookup__item">
+                              role="presentation">
                               <a
-                                className="slds-truncate react-slds-candidate"
+                                className="slds-lookup__item-action react-slds-candidate"
                                 onBlur={[Function]}
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
                                 role="option"
                                 tabIndex={-1}>
-                                <svg
-                                  aria-hidden={true}
-                                  className="slds-icon slds-icon--small slds-icon-standard-contact"
-                                  style={undefined}>
-                                  <use
-                                    xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#contact" />
-                                </svg>
-                                Contact
+                                <span
+                                  className="slds-media slds-media--center slds-truncate">
+                                  <svg
+                                    aria-hidden={true}
+                                    className="slds-icon slds-icon--small slds-icon-standard-contact slds-media__figure"
+                                    style={undefined}>
+                                    <use
+                                      xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#contact" />
+                                  </svg>
+                                  <div
+                                    className="slds-media__body slds-truncate">
+                                    <span
+                                      className="slds-lookup__result-text slds-truncate">
+                                      Contact
+                                    </span>
+                                  </div>
+                                </span>
                               </a>
                             </li>
                             <li
-                              className="slds-lookup__item">
+                              role="presentation">
                               <a
-                                className="slds-truncate react-slds-candidate"
+                                className="slds-lookup__item-action react-slds-candidate"
                                 onBlur={[Function]}
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
                                 role="option"
                                 tabIndex={-1}>
-                                <svg
-                                  aria-hidden={true}
-                                  className="slds-icon slds-icon--small slds-icon-standard-opportunity"
-                                  style={undefined}>
-                                  <use
-                                    xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
-                                </svg>
-                                Opportunity
+                                <span
+                                  className="slds-media slds-media--center slds-truncate">
+                                  <svg
+                                    aria-hidden={true}
+                                    className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                                    style={undefined}>
+                                    <use
+                                      xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
+                                  </svg>
+                                  <div
+                                    className="slds-media__body slds-truncate">
+                                    <span
+                                      className="slds-lookup__result-text slds-truncate">
+                                      Opportunity
+                                    </span>
+                                  </div>
+                                </span>
                               </a>
                             </li>
                           </ul>

--- a/src/scripts/Lookup.js
+++ b/src/scripts/Lookup.js
@@ -65,6 +65,7 @@ const LookupEntryType = PropTypes.shape({
   icon: PropTypes.string,
   label: PropTypes.string,
   value: PropTypes.string,
+  meta: PropTypes.string,
 });
 
 LookupSelection.propTypes = {
@@ -360,26 +361,37 @@ export class LookupCandidateList extends Component {
   }
 
   renderCandidate(entry) {
+    const { category, icon, label, value, meta } = entry;
     return (
-      <li className='slds-lookup__item' key={ entry.value }>
+      <li key={ value } role='presentation'>
         <a
-          className='slds-truncate react-slds-candidate'
+          className='slds-lookup__item-action react-slds-candidate'
           tabIndex={ -1 }
           role='option'
           onKeyDown={ e => e.keyCode === 13 && this.onSelect(entry) }
           onBlur={ this.props.onBlur }
           onClick={ () => this.onSelect(entry) }
         >
-          {
-            entry.icon ?
-              <Icon
-                category={ entry.category }
-                icon={ entry.icon }
-                size='small'
-              /> :
-              undefined
-          }
-          { entry.label }
+          <span className='slds-media slds-media--center slds-truncate'>
+            {
+              icon ?
+                <Icon
+                  className='slds-media__figure'
+                  category={ category }
+                  icon={ icon }
+                  size='small'
+                /> :
+                undefined
+            }
+            <div className='slds-media__body slds-truncate'>
+              <span className='slds-lookup__result-text slds-truncate'>{ label }</span>
+              {
+                meta ?
+                  <span className='slds-lookup__result-meta slds-truncate'>{ meta }</span> :
+                  undefined
+              }
+            </div>
+          </span>
         </a>
       </li>
     );

--- a/stories/LookupStories.js
+++ b/stories/LookupStories.js
@@ -15,6 +15,7 @@ const COMPANY_DATA = COMPANIES.map((label, i) => ({
   icon: 'standard:account',
   label,
   value: `10000${i}`,
+  meta: '(888)000-0000 / 1234 XXX Ave, BBB City, CA, 90210 USA',
   scope: 'Account',
 }));
 


### PR DESCRIPTION
Support meta information in lookup entry. If no meta in entry it will only shows its label.

<img width="163" alt="react_storybook" src="https://user-images.githubusercontent.com/23387/28761222-09a037d2-75e8-11e7-8fdb-a29c492891ac.png">
