### PR TITLE
Fix lookup candidate rendering in ie11

### DIFF
--- a/.storybook/__storyshots__/Form.shot
+++ b/.storybook/__storyshots__/Form.shot
@@ -425,16 +425,21 @@ exports[`Compound Form`] = `
                               role="option"
                               tabIndex={-1}>
                               <span
-                                className="slds-media slds-media--center slds-truncate">
+                                className="slds-truncate"
+                                style={
+                                  Object {
+                                    "display": "inline-flex",
+                                  }
+                                }>
                                 <svg
                                   aria-hidden={true}
-                                  className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                                  className="slds-icon slds-icon--small slds-icon-standard-account"
                                   style={undefined}>
                                   <use
                                     xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                                 </svg>
                                 <div
-                                  className="slds-media__body slds-truncate">
+                                  className="slds-truncate">
                                   <span
                                     className="slds-lookup__result-text slds-truncate">
                                     Account
@@ -453,16 +458,21 @@ exports[`Compound Form`] = `
                               role="option"
                               tabIndex={-1}>
                               <span
-                                className="slds-media slds-media--center slds-truncate">
+                                className="slds-truncate"
+                                style={
+                                  Object {
+                                    "display": "inline-flex",
+                                  }
+                                }>
                                 <svg
                                   aria-hidden={true}
-                                  className="slds-icon slds-icon--small slds-icon-standard-contact slds-media__figure"
+                                  className="slds-icon slds-icon--small slds-icon-standard-contact"
                                   style={undefined}>
                                   <use
                                     xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#contact" />
                                 </svg>
                                 <div
-                                  className="slds-media__body slds-truncate">
+                                  className="slds-truncate">
                                   <span
                                     className="slds-lookup__result-text slds-truncate">
                                     Contact
@@ -481,16 +491,21 @@ exports[`Compound Form`] = `
                               role="option"
                               tabIndex={-1}>
                               <span
-                                className="slds-media slds-media--center slds-truncate">
+                                className="slds-truncate"
+                                style={
+                                  Object {
+                                    "display": "inline-flex",
+                                  }
+                                }>
                                 <svg
                                   aria-hidden={true}
-                                  className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                                  className="slds-icon slds-icon--small slds-icon-standard-opportunity"
                                   style={undefined}>
                                   <use
                                     xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
                                 </svg>
                                 <div
-                                  className="slds-media__body slds-truncate">
+                                  className="slds-truncate">
                                   <span
                                     className="slds-lookup__result-text slds-truncate">
                                     Opportunity
@@ -7566,16 +7581,21 @@ exports[`Horizontal Form`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Account
@@ -7594,16 +7614,21 @@ exports[`Horizontal Form`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-contact slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-contact"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#contact" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Contact
@@ -7622,16 +7647,21 @@ exports[`Horizontal Form`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-opportunity"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Opportunity
@@ -13522,16 +13552,21 @@ exports[`Stacked Form`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Account
@@ -13550,16 +13585,21 @@ exports[`Stacked Form`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-contact slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-contact"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#contact" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Contact
@@ -13578,16 +13618,21 @@ exports[`Stacked Form`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-opportunity"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Opportunity

--- a/.storybook/__storyshots__/Lookup.shot
+++ b/.storybook/__storyshots__/Lookup.shot
@@ -133,16 +133,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Apple Inc.
@@ -165,16 +170,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Alphabet Inc.
@@ -197,16 +207,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Microsoft Corporation
@@ -229,16 +244,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Facebook, Inc.
@@ -261,16 +281,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Intel Corporation
@@ -293,16 +318,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Oracle Corporation
@@ -325,16 +355,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Cisco Systems, Inc.
@@ -357,16 +392,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               International Business Machines Corporation
@@ -389,16 +429,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               QUALCOMM Incorporated
@@ -421,16 +466,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Texas Instruments Incorporated
@@ -453,16 +503,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Salesforce.com Inc
@@ -485,16 +540,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               EMC Corporation
@@ -517,16 +577,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Adobe Systems Incorporated
@@ -549,16 +614,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Automatic Data Processing, Inc.
@@ -581,16 +651,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Cognizant Technology Solutions Corporation
@@ -613,16 +688,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Broadcom Corporation
@@ -645,16 +725,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Illinois Tool Works Inc.
@@ -677,16 +762,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Yahoo! Inc.
@@ -709,16 +799,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               LinkedIn Corporation
@@ -741,16 +836,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Activision Blizzard, Inc
@@ -773,16 +873,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Intuit Inc.
@@ -805,16 +910,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Vmware, Inc.
@@ -837,16 +947,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Fiserv, Inc.
@@ -869,16 +984,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Applied Materials, Inc.
@@ -901,16 +1021,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Cerner Corporation
@@ -933,16 +1058,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Electronic Arts Inc.
@@ -965,16 +1095,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               HP Inc.
@@ -997,16 +1132,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Omnicom Group Inc.
@@ -1029,16 +1169,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               NVIDIA Corporation
@@ -1061,16 +1206,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Analog Devices, Inc.
@@ -1093,16 +1243,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               SanDisk Corporation
@@ -1125,16 +1280,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Micron Technology, Inc.
@@ -1157,16 +1317,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Red Hat, Inc.
@@ -1189,16 +1354,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Palo Alto Networks, Inc.
@@ -1221,16 +1391,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Workday, Inc.
@@ -1253,16 +1428,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Symantec Corporation
@@ -1285,16 +1465,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Western Digital Corporation
@@ -1317,16 +1502,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Skyworks Solutions, Inc.
@@ -1349,16 +1539,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               ServiceNow, Inc.
@@ -1381,16 +1576,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Autodesk, Inc.
@@ -1413,16 +1613,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Verisk Analytics, Inc.
@@ -1445,16 +1650,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               CA Inc.
@@ -1477,16 +1687,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Lam Research Corporation
@@ -1509,16 +1724,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Motorola Solutions, Inc.
@@ -1541,16 +1761,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Xilinx, Inc.
@@ -1573,16 +1798,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               TripAdvisor, Inc.
@@ -1605,16 +1835,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Citrix Systems, Inc.
@@ -1637,16 +1872,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Juniper Networks, Inc.
@@ -1669,16 +1909,21 @@ exports[`Active`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Maxim Integrated Products, Inc.
@@ -4427,16 +4672,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Apple Inc.
@@ -4459,16 +4709,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Alphabet Inc.
@@ -4491,16 +4746,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Microsoft Corporation
@@ -4523,16 +4783,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Facebook, Inc.
@@ -4555,16 +4820,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Intel Corporation
@@ -4587,16 +4857,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Oracle Corporation
@@ -4619,16 +4894,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Cisco Systems, Inc.
@@ -4651,16 +4931,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             International Business Machines Corporation
@@ -4683,16 +4968,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             QUALCOMM Incorporated
@@ -4715,16 +5005,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Texas Instruments Incorporated
@@ -4747,16 +5042,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Salesforce.com Inc
@@ -4779,16 +5079,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             EMC Corporation
@@ -4811,16 +5116,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Adobe Systems Incorporated
@@ -4843,16 +5153,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Automatic Data Processing, Inc.
@@ -4875,16 +5190,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Cognizant Technology Solutions Corporation
@@ -4907,16 +5227,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Broadcom Corporation
@@ -4939,16 +5264,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Illinois Tool Works Inc.
@@ -4971,16 +5301,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Yahoo! Inc.
@@ -5003,16 +5338,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             LinkedIn Corporation
@@ -5035,16 +5375,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Activision Blizzard, Inc
@@ -5067,16 +5412,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Intuit Inc.
@@ -5099,16 +5449,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Vmware, Inc.
@@ -5131,16 +5486,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Fiserv, Inc.
@@ -5163,16 +5523,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Applied Materials, Inc.
@@ -5195,16 +5560,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Cerner Corporation
@@ -5227,16 +5597,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Electronic Arts Inc.
@@ -5259,16 +5634,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             HP Inc.
@@ -5291,16 +5671,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Omnicom Group Inc.
@@ -5323,16 +5708,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             NVIDIA Corporation
@@ -5355,16 +5745,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Analog Devices, Inc.
@@ -5387,16 +5782,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             SanDisk Corporation
@@ -5419,16 +5819,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Micron Technology, Inc.
@@ -5451,16 +5856,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Red Hat, Inc.
@@ -5483,16 +5893,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Palo Alto Networks, Inc.
@@ -5515,16 +5930,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Workday, Inc.
@@ -5547,16 +5967,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Symantec Corporation
@@ -5579,16 +6004,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Western Digital Corporation
@@ -5611,16 +6041,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Skyworks Solutions, Inc.
@@ -5643,16 +6078,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             ServiceNow, Inc.
@@ -5675,16 +6115,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Autodesk, Inc.
@@ -5707,16 +6152,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Verisk Analytics, Inc.
@@ -5739,16 +6189,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             CA Inc.
@@ -5771,16 +6226,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Lam Research Corporation
@@ -5803,16 +6263,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Motorola Solutions, Inc.
@@ -5835,16 +6300,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Xilinx, Inc.
@@ -5867,16 +6337,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             TripAdvisor, Inc.
@@ -5899,16 +6374,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Citrix Systems, Inc.
@@ -5931,16 +6411,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Juniper Networks, Inc.
@@ -5963,16 +6448,21 @@ exports[`Controlled with knobs`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Maxim Integrated Products, Inc.
@@ -10881,16 +11371,21 @@ exports[`Uncontrolled`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Apple Inc.
@@ -10913,16 +11408,21 @@ exports[`Uncontrolled`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Alphabet Inc.
@@ -10945,16 +11445,21 @@ exports[`Uncontrolled`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Adobe Systems Incorporated
@@ -10977,16 +11482,21 @@ exports[`Uncontrolled`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Automatic Data Processing, Inc.
@@ -11009,16 +11519,21 @@ exports[`Uncontrolled`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Activision Blizzard, Inc
@@ -11041,16 +11556,21 @@ exports[`Uncontrolled`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Applied Materials, Inc.
@@ -11073,16 +11593,21 @@ exports[`Uncontrolled`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Analog Devices, Inc.
@@ -11105,16 +11630,21 @@ exports[`Uncontrolled`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-account"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Autodesk, Inc.
@@ -12354,16 +12884,21 @@ exports[`Uncontrolled with Multi Scope`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-opportunity"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Apple Inc. - New License
@@ -12382,16 +12917,21 @@ exports[`Uncontrolled with Multi Scope`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-opportunity"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Alphabet Inc. - Professional Service
@@ -12410,16 +12950,21 @@ exports[`Uncontrolled with Multi Scope`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-opportunity"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Adobe Systems Incorporated - New License
@@ -12438,16 +12983,21 @@ exports[`Uncontrolled with Multi Scope`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-opportunity"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Automatic Data Processing, Inc. - Professional Service
@@ -12466,16 +13016,21 @@ exports[`Uncontrolled with Multi Scope`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-opportunity"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Activision Blizzard, Inc - Hardware Renewal
@@ -12494,16 +13049,21 @@ exports[`Uncontrolled with Multi Scope`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-opportunity"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Applied Materials, Inc. - Hardware Renewal
@@ -12522,16 +13082,21 @@ exports[`Uncontrolled with Multi Scope`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-opportunity"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Analog Devices, Inc. - Professional Service
@@ -12550,16 +13115,21 @@ exports[`Uncontrolled with Multi Scope`] = `
                       role="option"
                       tabIndex={-1}>
                       <span
-                        className="slds-media slds-media--center slds-truncate">
+                        className="slds-truncate"
+                        style={
+                          Object {
+                            "display": "inline-flex",
+                          }
+                        }>
                         <svg
                           aria-hidden={true}
-                          className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                          className="slds-icon slds-icon--small slds-icon-standard-opportunity"
                           style={undefined}>
                           <use
                             xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
                         </svg>
                         <div
-                          className="slds-media__body slds-truncate">
+                          className="slds-truncate">
                           <span
                             className="slds-lookup__result-text slds-truncate">
                             Autodesk, Inc. - Hardware Renewal
@@ -14117,16 +14687,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Apple Inc.
@@ -14149,16 +14724,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Alphabet Inc.
@@ -14181,16 +14761,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Microsoft Corporation
@@ -14213,16 +14798,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Facebook, Inc.
@@ -14245,16 +14835,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Intel Corporation
@@ -14277,16 +14872,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Oracle Corporation
@@ -14309,16 +14909,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Cisco Systems, Inc.
@@ -14341,16 +14946,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               International Business Machines Corporation
@@ -14373,16 +14983,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               QUALCOMM Incorporated
@@ -14405,16 +15020,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Texas Instruments Incorporated
@@ -14437,16 +15057,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Salesforce.com Inc
@@ -14469,16 +15094,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               EMC Corporation
@@ -14501,16 +15131,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Adobe Systems Incorporated
@@ -14533,16 +15168,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Automatic Data Processing, Inc.
@@ -14565,16 +15205,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Cognizant Technology Solutions Corporation
@@ -14597,16 +15242,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Broadcom Corporation
@@ -14629,16 +15279,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Illinois Tool Works Inc.
@@ -14661,16 +15316,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Yahoo! Inc.
@@ -14693,16 +15353,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               LinkedIn Corporation
@@ -14725,16 +15390,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Activision Blizzard, Inc
@@ -14757,16 +15427,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Intuit Inc.
@@ -14789,16 +15464,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Vmware, Inc.
@@ -14821,16 +15501,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Fiserv, Inc.
@@ -14853,16 +15538,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Applied Materials, Inc.
@@ -14885,16 +15575,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Cerner Corporation
@@ -14917,16 +15612,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Electronic Arts Inc.
@@ -14949,16 +15649,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               HP Inc.
@@ -14981,16 +15686,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Omnicom Group Inc.
@@ -15013,16 +15723,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               NVIDIA Corporation
@@ -15045,16 +15760,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Analog Devices, Inc.
@@ -15077,16 +15797,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               SanDisk Corporation
@@ -15109,16 +15834,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Micron Technology, Inc.
@@ -15141,16 +15871,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Red Hat, Inc.
@@ -15173,16 +15908,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Palo Alto Networks, Inc.
@@ -15205,16 +15945,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Workday, Inc.
@@ -15237,16 +15982,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Symantec Corporation
@@ -15269,16 +16019,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Western Digital Corporation
@@ -15301,16 +16056,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Skyworks Solutions, Inc.
@@ -15333,16 +16093,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               ServiceNow, Inc.
@@ -15365,16 +16130,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Autodesk, Inc.
@@ -15397,16 +16167,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Verisk Analytics, Inc.
@@ -15429,16 +16204,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               CA Inc.
@@ -15461,16 +16241,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Lam Research Corporation
@@ -15493,16 +16278,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Motorola Solutions, Inc.
@@ -15525,16 +16315,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Xilinx, Inc.
@@ -15557,16 +16352,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               TripAdvisor, Inc.
@@ -15589,16 +16389,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Citrix Systems, Inc.
@@ -15621,16 +16426,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Juniper Networks, Inc.
@@ -15653,16 +16463,21 @@ exports[`With list header/footer`] = `
                         role="option"
                         tabIndex={-1}>
                         <span
-                          className="slds-media slds-media--center slds-truncate">
+                          className="slds-truncate"
+                          style={
+                            Object {
+                              "display": "inline-flex",
+                            }
+                          }>
                           <svg
                             aria-hidden={true}
-                            className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                            className="slds-icon slds-icon--small slds-icon-standard-account"
                             style={undefined}>
                             <use
                               xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                           </svg>
                           <div
-                            className="slds-media__body slds-truncate">
+                            className="slds-truncate">
                             <span
                               className="slds-lookup__result-text slds-truncate">
                               Maxim Integrated Products, Inc.

--- a/.storybook/__storyshots__/Modal.shot
+++ b/.storybook/__storyshots__/Modal.shot
@@ -3366,16 +3366,21 @@ exports[`Form elements`] = `
                                 role="option"
                                 tabIndex={-1}>
                                 <span
-                                  className="slds-media slds-media--center slds-truncate">
+                                  className="slds-truncate"
+                                  style={
+                                    Object {
+                                      "display": "inline-flex",
+                                    }
+                                  }>
                                   <svg
                                     aria-hidden={true}
-                                    className="slds-icon slds-icon--small slds-icon-standard-account slds-media__figure"
+                                    className="slds-icon slds-icon--small slds-icon-standard-account"
                                     style={undefined}>
                                     <use
                                       xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account" />
                                   </svg>
                                   <div
-                                    className="slds-media__body slds-truncate">
+                                    className="slds-truncate">
                                     <span
                                       className="slds-lookup__result-text slds-truncate">
                                       Account
@@ -3394,16 +3399,21 @@ exports[`Form elements`] = `
                                 role="option"
                                 tabIndex={-1}>
                                 <span
-                                  className="slds-media slds-media--center slds-truncate">
+                                  className="slds-truncate"
+                                  style={
+                                    Object {
+                                      "display": "inline-flex",
+                                    }
+                                  }>
                                   <svg
                                     aria-hidden={true}
-                                    className="slds-icon slds-icon--small slds-icon-standard-contact slds-media__figure"
+                                    className="slds-icon slds-icon--small slds-icon-standard-contact"
                                     style={undefined}>
                                     <use
                                       xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#contact" />
                                   </svg>
                                   <div
-                                    className="slds-media__body slds-truncate">
+                                    className="slds-truncate">
                                     <span
                                       className="slds-lookup__result-text slds-truncate">
                                       Contact
@@ -3422,16 +3432,21 @@ exports[`Form elements`] = `
                                 role="option"
                                 tabIndex={-1}>
                                 <span
-                                  className="slds-media slds-media--center slds-truncate">
+                                  className="slds-truncate"
+                                  style={
+                                    Object {
+                                      "display": "inline-flex",
+                                    }
+                                  }>
                                   <svg
                                     aria-hidden={true}
-                                    className="slds-icon slds-icon--small slds-icon-standard-opportunity slds-media__figure"
+                                    className="slds-icon slds-icon--small slds-icon-standard-opportunity"
                                     style={undefined}>
                                     <use
                                       xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity" />
                                   </svg>
                                   <div
-                                    className="slds-media__body slds-truncate">
+                                    className="slds-truncate">
                                     <span
                                       className="slds-lookup__result-text slds-truncate">
                                       Opportunity

--- a/src/scripts/Lookup.js
+++ b/src/scripts/Lookup.js
@@ -372,18 +372,17 @@ export class LookupCandidateList extends Component {
           onBlur={ this.props.onBlur }
           onClick={ () => this.onSelect(entry) }
         >
-          <span className='slds-media slds-media--center slds-truncate'>
+          <span className='slds-truncate' style={ { display: 'inline-flex' } }>
             {
               icon ?
                 <Icon
-                  className='slds-media__figure'
                   category={ category }
                   icon={ icon }
                   size='small'
                 /> :
                 undefined
             }
-            <div className='slds-media__body slds-truncate'>
+            <div className='slds-truncate'>
               <span className='slds-lookup__result-text slds-truncate'>{ label }</span>
               {
                 meta ?


### PR DESCRIPTION
IE11 has problem rendering slds-media in lookup candidate. Change to use direct styling of inline-flex in display.