### PR TITLE
Add default portal class to work without adding setting

### DIFF
--- a/src/scripts/AutoAlign.js
+++ b/src/scripts/AutoAlign.js
@@ -221,7 +221,7 @@ export default function autoAlign(options) {
         ...pprops
       } = this.props;
       const {
-        portalClassName,
+        portalClassName = 'slds-scope',
         portalStyle = {},
       } = this.context;
       const {


### PR DESCRIPTION
As the SLDS in VF assumes elements to locate under the `slds-scope` DOM element, a portal (dropdown) element - which locates under the document.body - should be marked with class name of `slds-scope`.
The `<CustomSettings>` component can set this, but the default class name should be `slds-scope` without adding custom setting.
Close #273