### PR TITLE
Revert "#278 fix-blur-in-icon-click"

### DIFF
--- a/src/scripts/DateInput.js
+++ b/src/scripts/DateInput.js
@@ -243,8 +243,9 @@ export default class DateInput extends Component {
         />
         <span
           tabIndex={ -1 }
-          style={ props.disabled ? undefined : { cursor: 'pointer' } }
+          style={ props.disabled ? undefined : { cursor: 'pointer', outline: 'none' } }
           onClick={ props.disabled ? undefined : this.onDateIconClick }
+          onBlur={ this.onInputBlur }
         >
           <Icon icon='event' className='slds-input__icon' />
         </span>

--- a/src/scripts/DateInput.js
+++ b/src/scripts/DateInput.js
@@ -243,9 +243,8 @@ export default class DateInput extends Component {
         />
         <span
           tabIndex={ -1 }
-          style={ props.disabled ? undefined : { position: 'relative', cursor: 'pointer', outline: 'none' } }
+          style={ props.disabled ? undefined : { cursor: 'pointer' } }
           onClick={ props.disabled ? undefined : this.onDateIconClick }
-          onBlur={ this.onInputBlur }
         >
           <Icon icon='event' className='slds-input__icon' />
         </span>

--- a/src/scripts/Lookup.js
+++ b/src/scripts/Lookup.js
@@ -257,6 +257,7 @@ export class LookupSearch extends Component {
           tabIndex={ -1 }
           style={ props.disabled ? undefined : { cursor: 'pointer' } }
           onClick={ props.disabled ? undefined : this.onLookupIconClick }
+          onBlur={ this.onInputBlur }
         >
           <Icon
             icon='search'

--- a/src/scripts/Lookup.js
+++ b/src/scripts/Lookup.js
@@ -255,9 +255,8 @@ export class LookupSearch extends Component {
         />
         <span
           tabIndex={ -1 }
-          style={ props.disabled ? undefined : { position: 'relative', cursor: 'pointer', outline: 'none' } }
+          style={ props.disabled ? undefined : { cursor: 'pointer' } }
           onClick={ props.disabled ? undefined : this.onLookupIconClick }
-          onBlur={ this.onInputBlur }
         >
           <Icon
             icon='search'

--- a/src/scripts/Lookup.js
+++ b/src/scripts/Lookup.js
@@ -255,7 +255,7 @@ export class LookupSearch extends Component {
         />
         <span
           tabIndex={ -1 }
-          style={ props.disabled ? undefined : { cursor: 'pointer' } }
+          style={ props.disabled ? undefined : { cursor: 'pointer', outline: 'none' } }
           onClick={ props.disabled ? undefined : this.onLookupIconClick }
           onBlur={ this.onInputBlur }
         >

--- a/test/storyshots/__snapshots__/storyshots.test.js.snap
+++ b/test/storyshots/__snapshots__/storyshots.test.js.snap
@@ -6528,6 +6528,7 @@ exports[`Storyshots Form Compound Form 1`] = `
                         type={undefined}
                         value={undefined} />
                       <span
+                        onBlur={[Function]}
                         onClick={[Function]}
                         style={
                           Object {
@@ -6983,6 +6984,7 @@ exports[`Storyshots Form Horizontal Form 1`] = `
                   type={undefined}
                   value={undefined} />
                 <span
+                  onBlur={[Function]}
                   onClick={[Function]}
                   style={
                     Object {
@@ -7409,6 +7411,7 @@ exports[`Storyshots Form Stacked Form 1`] = `
                   type={undefined}
                   value={undefined} />
                 <span
+                  onBlur={[Function]}
                   onClick={[Function]}
                   style={
                     Object {
@@ -24736,6 +24739,7 @@ exports[`Storyshots Lookup Active 1`] = `
                   type={undefined}
                   value="A" />
                 <span
+                  onBlur={[Function]}
                   onClick={[Function]}
                   style={
                     Object {
@@ -26906,6 +26910,7 @@ exports[`Storyshots Lookup Controlled 1`] = `
                 type={undefined}
                 value="" />
               <span
+                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
@@ -27047,6 +27052,7 @@ exports[`Storyshots Lookup Controlled with Multi Scope 1`] = `
                   type={undefined}
                   value="" />
                 <span
+                  onBlur={[Function]}
                   onClick={[Function]}
                   style={
                     Object {
@@ -27146,6 +27152,7 @@ exports[`Storyshots Lookup Controlled with knobs 1`] = `
                 type={undefined}
                 value={undefined} />
               <span
+                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
@@ -27243,6 +27250,7 @@ exports[`Storyshots Lookup In Loading 1`] = `
                 type={undefined}
                 value="A" />
               <span
+                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
@@ -27420,6 +27428,7 @@ exports[`Storyshots Lookup Multi Scope - Disabled 1`] = `
                   type={undefined}
                   value={undefined} />
                 <span
+                  onBlur={[Function]}
                   onClick={undefined}
                   style={undefined}
                   tabIndex={-1}>
@@ -27558,6 +27567,7 @@ exports[`Storyshots Lookup Multi Scope 1`] = `
                   type={undefined}
                   value="A" />
                 <span
+                  onBlur={[Function]}
                   onClick={[Function]}
                   style={
                     Object {
@@ -27656,6 +27666,7 @@ exports[`Storyshots Lookup Uncontrolled 1`] = `
                 type={undefined}
                 value="A" />
               <span
+                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
@@ -27797,6 +27808,7 @@ exports[`Storyshots Lookup Uncontrolled with Multi Scope 1`] = `
                   type={undefined}
                   value="A" />
                 <span
+                  onBlur={[Function]}
                   onClick={[Function]}
                   style={
                     Object {
@@ -27901,6 +27913,7 @@ exports[`Storyshots Lookup With list header/footer 1`] = `
                   type={undefined}
                   value="A" />
                 <span
+                  onBlur={[Function]}
                   onClick={[Function]}
                   style={
                     Object {
@@ -30111,6 +30124,7 @@ exports[`Storyshots Lookup With search icon in left 1`] = `
                 type={undefined}
                 value="A" />
               <span
+                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
@@ -30208,6 +30222,7 @@ exports[`Storyshots Lookup With search text 1`] = `
                 type={undefined}
                 value="A" />
               <span
+                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
@@ -31262,6 +31277,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                             type={undefined}
                             value={undefined} />
                           <span
+                            onBlur={[Function]}
                             onClick={[Function]}
                             style={
                               Object {

--- a/test/storyshots/__snapshots__/storyshots.test.js.snap
+++ b/test/storyshots/__snapshots__/storyshots.test.js.snap
@@ -2154,13 +2154,10 @@ exports[`Storyshots DateInput Controlled with knobs 1`] = `
                 type={undefined}
                 value={undefined} />
               <span
-                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
-                    "outline": "none",
-                    "position": "relative",
                   }
                 }
                 tabIndex={-1}>
@@ -2250,13 +2247,10 @@ exports[`Storyshots DateInput Default 1`] = `
                 type={undefined}
                 value="04/13/2016" />
               <span
-                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
-                    "outline": "none",
-                    "position": "relative",
                   }
                 }
                 tabIndex={-1}>
@@ -2347,7 +2341,6 @@ exports[`Storyshots DateInput Disabled 1`] = `
                 type={undefined}
                 value="04/13/2016" />
               <span
-                onBlur={[Function]}
                 onClick={undefined}
                 style={undefined}
                 tabIndex={-1}>
@@ -2441,13 +2434,10 @@ exports[`Storyshots DateInput Error 1`] = `
                 type={undefined}
                 value="04/13/2016" />
               <span
-                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
-                    "outline": "none",
-                    "position": "relative",
                   }
                 }
                 tabIndex={-1}>
@@ -2541,13 +2531,10 @@ exports[`Storyshots DateInput Include time data 1`] = `
                 type={undefined}
                 value="2016/04/13 23:42:56" />
               <span
-                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
-                    "outline": "none",
-                    "position": "relative",
                   }
                 }
                 tabIndex={-1}>
@@ -2641,13 +2628,10 @@ exports[`Storyshots DateInput Required 1`] = `
                 type={undefined}
                 value="04/13/2016" />
               <span
-                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
-                    "outline": "none",
-                    "position": "relative",
                   }
                 }
                 tabIndex={-1}>
@@ -2737,13 +2721,10 @@ exports[`Storyshots DateInput With date format 1`] = `
                 type={undefined}
                 value="2016.04.13" />
               <span
-                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
-                    "outline": "none",
-                    "position": "relative",
                   }
                 }
                 tabIndex={-1}>
@@ -2833,13 +2814,10 @@ exports[`Storyshots DateInput With min/max date 1`] = `
                 type={undefined}
                 value="04/13/2016" />
               <span
-                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
-                    "outline": "none",
-                    "position": "relative",
                   }
                 }
                 tabIndex={-1}>
@@ -6500,13 +6478,10 @@ exports[`Storyshots Form Compound Form 1`] = `
                         type={undefined}
                         value={undefined} />
                       <span
-                        onBlur={[Function]}
                         onClick={[Function]}
                         style={
                           Object {
                             "cursor": "pointer",
-                            "outline": "none",
-                            "position": "relative",
                           }
                         }
                         tabIndex={-1}>
@@ -6553,13 +6528,10 @@ exports[`Storyshots Form Compound Form 1`] = `
                         type={undefined}
                         value={undefined} />
                       <span
-                        onBlur={[Function]}
                         onClick={[Function]}
                         style={
                           Object {
                             "cursor": "pointer",
-                            "outline": "none",
-                            "position": "relative",
                           }
                         }
                         tabIndex={-1}>
@@ -6964,13 +6936,10 @@ exports[`Storyshots Form Horizontal Form 1`] = `
                   type={undefined}
                   value={undefined} />
                 <span
-                  onBlur={[Function]}
                   onClick={[Function]}
                   style={
                     Object {
                       "cursor": "pointer",
-                      "outline": "none",
-                      "position": "relative",
                     }
                   }
                   tabIndex={-1}>
@@ -7014,13 +6983,10 @@ exports[`Storyshots Form Horizontal Form 1`] = `
                   type={undefined}
                   value={undefined} />
                 <span
-                  onBlur={[Function]}
                   onClick={[Function]}
                   style={
                     Object {
                       "cursor": "pointer",
-                      "outline": "none",
-                      "position": "relative",
                     }
                   }
                   tabIndex={-1}>
@@ -7396,13 +7362,10 @@ exports[`Storyshots Form Stacked Form 1`] = `
                   type={undefined}
                   value={undefined} />
                 <span
-                  onBlur={[Function]}
                   onClick={[Function]}
                   style={
                     Object {
                       "cursor": "pointer",
-                      "outline": "none",
-                      "position": "relative",
                     }
                   }
                   tabIndex={-1}>
@@ -7446,13 +7409,10 @@ exports[`Storyshots Form Stacked Form 1`] = `
                   type={undefined}
                   value={undefined} />
                 <span
-                  onBlur={[Function]}
                   onClick={[Function]}
                   style={
                     Object {
                       "cursor": "pointer",
-                      "outline": "none",
-                      "position": "relative",
                     }
                   }
                   tabIndex={-1}>
@@ -24776,13 +24736,10 @@ exports[`Storyshots Lookup Active 1`] = `
                   type={undefined}
                   value="A" />
                 <span
-                  onBlur={[Function]}
                   onClick={[Function]}
                   style={
                     Object {
                       "cursor": "pointer",
-                      "outline": "none",
-                      "position": "relative",
                     }
                   }
                   tabIndex={-1}>
@@ -26949,13 +26906,10 @@ exports[`Storyshots Lookup Controlled 1`] = `
                 type={undefined}
                 value="" />
               <span
-                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
-                    "outline": "none",
-                    "position": "relative",
                   }
                 }
                 tabIndex={-1}>
@@ -27093,13 +27047,10 @@ exports[`Storyshots Lookup Controlled with Multi Scope 1`] = `
                   type={undefined}
                   value="" />
                 <span
-                  onBlur={[Function]}
                   onClick={[Function]}
                   style={
                     Object {
                       "cursor": "pointer",
-                      "outline": "none",
-                      "position": "relative",
                     }
                   }
                   tabIndex={-1}>
@@ -27195,13 +27146,10 @@ exports[`Storyshots Lookup Controlled with knobs 1`] = `
                 type={undefined}
                 value={undefined} />
               <span
-                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
-                    "outline": "none",
-                    "position": "relative",
                   }
                 }
                 tabIndex={-1}>
@@ -27295,13 +27243,10 @@ exports[`Storyshots Lookup In Loading 1`] = `
                 type={undefined}
                 value="A" />
               <span
-                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
-                    "outline": "none",
-                    "position": "relative",
                   }
                 }
                 tabIndex={-1}>
@@ -27475,7 +27420,6 @@ exports[`Storyshots Lookup Multi Scope - Disabled 1`] = `
                   type={undefined}
                   value={undefined} />
                 <span
-                  onBlur={[Function]}
                   onClick={undefined}
                   style={undefined}
                   tabIndex={-1}>
@@ -27614,13 +27558,10 @@ exports[`Storyshots Lookup Multi Scope 1`] = `
                   type={undefined}
                   value="A" />
                 <span
-                  onBlur={[Function]}
                   onClick={[Function]}
                   style={
                     Object {
                       "cursor": "pointer",
-                      "outline": "none",
-                      "position": "relative",
                     }
                   }
                   tabIndex={-1}>
@@ -27715,13 +27656,10 @@ exports[`Storyshots Lookup Uncontrolled 1`] = `
                 type={undefined}
                 value="A" />
               <span
-                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
-                    "outline": "none",
-                    "position": "relative",
                   }
                 }
                 tabIndex={-1}>
@@ -27859,13 +27797,10 @@ exports[`Storyshots Lookup Uncontrolled with Multi Scope 1`] = `
                   type={undefined}
                   value="A" />
                 <span
-                  onBlur={[Function]}
                   onClick={[Function]}
                   style={
                     Object {
                       "cursor": "pointer",
-                      "outline": "none",
-                      "position": "relative",
                     }
                   }
                   tabIndex={-1}>
@@ -27966,13 +27901,10 @@ exports[`Storyshots Lookup With list header/footer 1`] = `
                   type={undefined}
                   value="A" />
                 <span
-                  onBlur={[Function]}
                   onClick={[Function]}
                   style={
                     Object {
                       "cursor": "pointer",
-                      "outline": "none",
-                      "position": "relative",
                     }
                   }
                   tabIndex={-1}>
@@ -30179,13 +30111,10 @@ exports[`Storyshots Lookup With search icon in left 1`] = `
                 type={undefined}
                 value="A" />
               <span
-                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
-                    "outline": "none",
-                    "position": "relative",
                   }
                 }
                 tabIndex={-1}>
@@ -30279,13 +30208,10 @@ exports[`Storyshots Lookup With search text 1`] = `
                 type={undefined}
                 value="A" />
               <span
-                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
-                    "outline": "none",
-                    "position": "relative",
                   }
                 }
                 tabIndex={-1}>
@@ -31157,13 +31083,10 @@ exports[`Storyshots Modal Form elements 1`] = `
                                 type={undefined}
                                 value={undefined} />
                               <span
-                                onBlur={[Function]}
                                 onClick={[Function]}
                                 style={
                                   Object {
                                     "cursor": "pointer",
-                                    "outline": "none",
-                                    "position": "relative",
                                   }
                                 }
                                 tabIndex={-1}>
@@ -31203,13 +31126,10 @@ exports[`Storyshots Modal Form elements 1`] = `
                                 type={undefined}
                                 value={undefined} />
                               <span
-                                onBlur={[Function]}
                                 onClick={[Function]}
                                 style={
                                   Object {
                                     "cursor": "pointer",
-                                    "outline": "none",
-                                    "position": "relative",
                                   }
                                 }
                                 tabIndex={-1}>
@@ -31254,13 +31174,10 @@ exports[`Storyshots Modal Form elements 1`] = `
                             type={undefined}
                             value={undefined} />
                           <span
-                            onBlur={[Function]}
                             onClick={[Function]}
                             style={
                               Object {
                                 "cursor": "pointer",
-                                "outline": "none",
-                                "position": "relative",
                               }
                             }
                             tabIndex={-1}>
@@ -31345,13 +31262,10 @@ exports[`Storyshots Modal Form elements 1`] = `
                             type={undefined}
                             value={undefined} />
                           <span
-                            onBlur={[Function]}
                             onClick={[Function]}
                             style={
                               Object {
                                 "cursor": "pointer",
-                                "outline": "none",
-                                "position": "relative",
                               }
                             }
                             tabIndex={-1}>

--- a/test/storyshots/__snapshots__/storyshots.test.js.snap
+++ b/test/storyshots/__snapshots__/storyshots.test.js.snap
@@ -2154,10 +2154,12 @@ exports[`Storyshots DateInput Controlled with knobs 1`] = `
                 type={undefined}
                 value={undefined} />
               <span
+                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
+                    "outline": "none",
                   }
                 }
                 tabIndex={-1}>
@@ -2247,10 +2249,12 @@ exports[`Storyshots DateInput Default 1`] = `
                 type={undefined}
                 value="04/13/2016" />
               <span
+                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
+                    "outline": "none",
                   }
                 }
                 tabIndex={-1}>
@@ -2341,6 +2345,7 @@ exports[`Storyshots DateInput Disabled 1`] = `
                 type={undefined}
                 value="04/13/2016" />
               <span
+                onBlur={[Function]}
                 onClick={undefined}
                 style={undefined}
                 tabIndex={-1}>
@@ -2434,10 +2439,12 @@ exports[`Storyshots DateInput Error 1`] = `
                 type={undefined}
                 value="04/13/2016" />
               <span
+                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
+                    "outline": "none",
                   }
                 }
                 tabIndex={-1}>
@@ -2531,10 +2538,12 @@ exports[`Storyshots DateInput Include time data 1`] = `
                 type={undefined}
                 value="2016/04/13 23:42:56" />
               <span
+                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
+                    "outline": "none",
                   }
                 }
                 tabIndex={-1}>
@@ -2628,10 +2637,12 @@ exports[`Storyshots DateInput Required 1`] = `
                 type={undefined}
                 value="04/13/2016" />
               <span
+                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
+                    "outline": "none",
                   }
                 }
                 tabIndex={-1}>
@@ -2721,10 +2732,12 @@ exports[`Storyshots DateInput With date format 1`] = `
                 type={undefined}
                 value="2016.04.13" />
               <span
+                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
+                    "outline": "none",
                   }
                 }
                 tabIndex={-1}>
@@ -2814,10 +2827,12 @@ exports[`Storyshots DateInput With min/max date 1`] = `
                 type={undefined}
                 value="04/13/2016" />
               <span
+                onBlur={[Function]}
                 onClick={[Function]}
                 style={
                   Object {
                     "cursor": "pointer",
+                    "outline": "none",
                   }
                 }
                 tabIndex={-1}>
@@ -6478,10 +6493,12 @@ exports[`Storyshots Form Compound Form 1`] = `
                         type={undefined}
                         value={undefined} />
                       <span
+                        onBlur={[Function]}
                         onClick={[Function]}
                         style={
                           Object {
                             "cursor": "pointer",
+                            "outline": "none",
                           }
                         }
                         tabIndex={-1}>
@@ -6533,6 +6550,7 @@ exports[`Storyshots Form Compound Form 1`] = `
                         style={
                           Object {
                             "cursor": "pointer",
+                            "outline": "none",
                           }
                         }
                         tabIndex={-1}>
@@ -6937,10 +6955,12 @@ exports[`Storyshots Form Horizontal Form 1`] = `
                   type={undefined}
                   value={undefined} />
                 <span
+                  onBlur={[Function]}
                   onClick={[Function]}
                   style={
                     Object {
                       "cursor": "pointer",
+                      "outline": "none",
                     }
                   }
                   tabIndex={-1}>
@@ -6989,6 +7009,7 @@ exports[`Storyshots Form Horizontal Form 1`] = `
                   style={
                     Object {
                       "cursor": "pointer",
+                      "outline": "none",
                     }
                   }
                   tabIndex={-1}>
@@ -7364,10 +7385,12 @@ exports[`Storyshots Form Stacked Form 1`] = `
                   type={undefined}
                   value={undefined} />
                 <span
+                  onBlur={[Function]}
                   onClick={[Function]}
                   style={
                     Object {
                       "cursor": "pointer",
+                      "outline": "none",
                     }
                   }
                   tabIndex={-1}>
@@ -7416,6 +7439,7 @@ exports[`Storyshots Form Stacked Form 1`] = `
                   style={
                     Object {
                       "cursor": "pointer",
+                      "outline": "none",
                     }
                   }
                   tabIndex={-1}>
@@ -24744,6 +24768,7 @@ exports[`Storyshots Lookup Active 1`] = `
                   style={
                     Object {
                       "cursor": "pointer",
+                      "outline": "none",
                     }
                   }
                   tabIndex={-1}>
@@ -26915,6 +26940,7 @@ exports[`Storyshots Lookup Controlled 1`] = `
                 style={
                   Object {
                     "cursor": "pointer",
+                    "outline": "none",
                   }
                 }
                 tabIndex={-1}>
@@ -27057,6 +27083,7 @@ exports[`Storyshots Lookup Controlled with Multi Scope 1`] = `
                   style={
                     Object {
                       "cursor": "pointer",
+                      "outline": "none",
                     }
                   }
                   tabIndex={-1}>
@@ -27157,6 +27184,7 @@ exports[`Storyshots Lookup Controlled with knobs 1`] = `
                 style={
                   Object {
                     "cursor": "pointer",
+                    "outline": "none",
                   }
                 }
                 tabIndex={-1}>
@@ -27255,6 +27283,7 @@ exports[`Storyshots Lookup In Loading 1`] = `
                 style={
                   Object {
                     "cursor": "pointer",
+                    "outline": "none",
                   }
                 }
                 tabIndex={-1}>
@@ -27572,6 +27601,7 @@ exports[`Storyshots Lookup Multi Scope 1`] = `
                   style={
                     Object {
                       "cursor": "pointer",
+                      "outline": "none",
                     }
                   }
                   tabIndex={-1}>
@@ -27671,6 +27701,7 @@ exports[`Storyshots Lookup Uncontrolled 1`] = `
                 style={
                   Object {
                     "cursor": "pointer",
+                    "outline": "none",
                   }
                 }
                 tabIndex={-1}>
@@ -27813,6 +27844,7 @@ exports[`Storyshots Lookup Uncontrolled with Multi Scope 1`] = `
                   style={
                     Object {
                       "cursor": "pointer",
+                      "outline": "none",
                     }
                   }
                   tabIndex={-1}>
@@ -27918,6 +27950,7 @@ exports[`Storyshots Lookup With list header/footer 1`] = `
                   style={
                     Object {
                       "cursor": "pointer",
+                      "outline": "none",
                     }
                   }
                   tabIndex={-1}>
@@ -30129,6 +30162,7 @@ exports[`Storyshots Lookup With search icon in left 1`] = `
                 style={
                   Object {
                     "cursor": "pointer",
+                    "outline": "none",
                   }
                 }
                 tabIndex={-1}>
@@ -30227,6 +30261,7 @@ exports[`Storyshots Lookup With search text 1`] = `
                 style={
                   Object {
                     "cursor": "pointer",
+                    "outline": "none",
                   }
                 }
                 tabIndex={-1}>
@@ -31098,10 +31133,12 @@ exports[`Storyshots Modal Form elements 1`] = `
                                 type={undefined}
                                 value={undefined} />
                               <span
+                                onBlur={[Function]}
                                 onClick={[Function]}
                                 style={
                                   Object {
                                     "cursor": "pointer",
+                                    "outline": "none",
                                   }
                                 }
                                 tabIndex={-1}>
@@ -31141,10 +31178,12 @@ exports[`Storyshots Modal Form elements 1`] = `
                                 type={undefined}
                                 value={undefined} />
                               <span
+                                onBlur={[Function]}
                                 onClick={[Function]}
                                 style={
                                   Object {
                                     "cursor": "pointer",
+                                    "outline": "none",
                                   }
                                 }
                                 tabIndex={-1}>
@@ -31189,10 +31228,12 @@ exports[`Storyshots Modal Form elements 1`] = `
                             type={undefined}
                             value={undefined} />
                           <span
+                            onBlur={[Function]}
                             onClick={[Function]}
                             style={
                               Object {
                                 "cursor": "pointer",
+                                "outline": "none",
                               }
                             }
                             tabIndex={-1}>
@@ -31282,6 +31323,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                             style={
                               Object {
                                 "cursor": "pointer",
+                                "outline": "none",
                               }
                             }
                             tabIndex={-1}>


### PR DESCRIPTION
This reverts PR #278 .

Because the problem occurred in the PR seems fixed in current Firefox (v70.0 mac),
and that change now causes the broken layout issue in Chrome (I confirmed with Mac Chrome 78.0.3904.70).

![SS 2019-10-31 23 58 32](https://user-images.githubusercontent.com/1001444/67958891-40168b00-fc3b-11e9-86d6-74f28a5701b2.png)
