### PR TITLE
Use context instead of copying menuSelect handler to props

### DIFF
--- a/src/scripts/DropdownMenu.tsx
+++ b/src/scripts/DropdownMenu.tsx
@@ -129,6 +129,8 @@ class DropdownMenuItemInner extends Component<
       onBlur,
       onFocus,
       onMenuSelect,
+      onMenuBlur,
+      onMenuFocus,
       children,
       ...props
     } = this.props;
@@ -151,8 +153,8 @@ class DropdownMenuItemInner extends Component<
           aria-disabled={disabled}
           tabIndex={disabled ? undefined : tabIndex}
           onClick={disabled ? undefined : this.onMenuItemClick}
-          onBlur={disabled ? undefined : onBlur}
-          onFocus={disabled ? undefined : onFocus}
+          onBlur={disabled ? undefined : this.onMenuItemBlur}
+          onFocus={disabled ? undefined : this.onMenuItemFocus}
           onKeyDown={disabled ? undefined : this.onKeyDown}
         >
           <p className='slds-truncate'>


### PR DESCRIPTION
As re-creating children is not preferable and type safe.