### PR TITLE
Remove BEM Notation with Double Dashes

### DIFF
--- a/src/scripts/Badge.tsx
+++ b/src/scripts/Badge.tsx
@@ -7,7 +7,7 @@ export type BadgeProps = {
 } & HTMLAttributes<HTMLSpanElement>;
 
 export const Badge: React.FC<BadgeProps> = ({ type, label, ...props }) => {
-  const typeClassName = type ? `slds-theme--${type}` : null;
+  const typeClassName = type ? `slds-theme_${type}` : null;
   const badgeClassNames = classnames('slds-badge', typeClassName);
   return (
     <span className={badgeClassNames} {...props}>

--- a/src/scripts/BreadCrumbs.tsx
+++ b/src/scripts/BreadCrumbs.tsx
@@ -13,7 +13,7 @@ export const Crumb: React.FC<CrumbProps> = ({
 }) => {
   const text = children;
   const cClassName = classnames(
-    'slds-list__item slds-text-heading--label',
+    'slds-list__item slds-text-heading_label',
     className
   );
 
@@ -35,7 +35,7 @@ export const BreadCrumbs: React.FC<BreadCrumbsProps> = ({
   ...props
 }) => {
   const oClassName = classnames(
-    'slds-breadcrumb slds-list--horizontal',
+    'slds-breadcrumb slds-list_horizontal',
     className
   );
 

--- a/src/scripts/Button.tsx
+++ b/src/scripts/Button.tsx
@@ -100,11 +100,11 @@ export class Button extends Component<ButtonProps, {}> {
       buttonRef,
       ...props
     } = this.props;
-    const typeClassName = type ? `slds-button--${type}` : null;
+    const typeClassName = type ? `slds-button_${type}` : null;
     const btnClassNames = classnames(className, 'slds-button', typeClassName, {
       'slds-is-selected': selected,
-      [`slds-button--${size}`]: size && !/^icon-/.test(type || ''),
-      [`slds-button--icon-${size}`]:
+      [`slds-button_${size}`]: size && !/^icon-/.test(type || ''),
+      [`slds-button_icon-${size}`]:
         /^(x-small|small)$/.test(size || '') && /^icon-/.test(type || ''),
     });
 
@@ -155,11 +155,11 @@ export const ButtonIcon: React.FC<ButtonIconProps> = ({
 }) => {
   const alignClassName =
     align && ICON_ALIGNS.indexOf(align) >= 0
-      ? `slds-button__icon--${align}`
+      ? `slds-button__icon_${align}`
       : null;
   const sizeClassName =
-    size && ICON_SIZES.indexOf(size) >= 0 ? `slds-button__icon--${size}` : null;
-  const inverseClassName = inverse ? 'slds-button__icon--inverse' : null;
+    size && ICON_SIZES.indexOf(size) >= 0 ? `slds-button__icon_${size}` : null;
+  const inverseClassName = inverse ? 'slds-button__icon_inverse' : null;
   const iconClassNames = classnames(
     'slds-button__icon',
     alignClassName,

--- a/src/scripts/Button.tsx
+++ b/src/scripts/Button.tsx
@@ -103,7 +103,6 @@ export class Button extends Component<ButtonProps, {}> {
     const typeClassName = type ? `slds-button_${type}` : null;
     const btnClassNames = classnames(className, 'slds-button', typeClassName, {
       'slds-is-selected': selected,
-      [`slds-button_${size}`]: size && !/^icon-/.test(type || ''),
       [`slds-button_icon-${size}`]:
         /^(x-small|small)$/.test(size || '') && /^icon-/.test(type || ''),
     });

--- a/src/scripts/Checkbox.tsx
+++ b/src/scripts/Checkbox.tsx
@@ -42,7 +42,7 @@ export class Checkbox extends Component<CheckboxProps> {
         className={checkClassNames}
       >
         <input type='checkbox' {...props} />
-        <span className='slds-checkbox--faux' />
+        <span className='slds-checkbox_faux' />
         <span className='slds-form-element__label'>{label}</span>
       </label>
     );

--- a/src/scripts/CheckboxGroup.tsx
+++ b/src/scripts/CheckboxGroup.tsx
@@ -76,7 +76,7 @@ export class CheckboxGroup<
         'slds-is-required': required,
       },
       typeof totalCols === 'number'
-        ? `slds-size--${cols || 1}-of-${totalCols}`
+        ? `slds-size_${cols || 1}-of-${totalCols}`
         : null
     );
     const grpStyles =
@@ -99,7 +99,7 @@ export class CheckboxGroup<
         onChange={this.onChange}
         {...props}
       >
-        <legend className='slds-form-element__label slds-form-element__label--top'>
+        <legend className='slds-form-element__label'>
           {label}
           {required ? <abbr className='slds-required'>*</abbr> : undefined}
         </legend>

--- a/src/scripts/Container.tsx
+++ b/src/scripts/Container.tsx
@@ -15,8 +15,8 @@ export const Container: React.FC<ContainerProps> = ({
 }) => {
   const ctClassNames = classnames(
     className,
-    `slds-container--${size || 'fluid'}`,
-    align ? `slds-container--${align}` : null
+    `slds-container_${size || 'fluid'}`,
+    align ? `slds-container_${align}` : null
   );
   return (
     <div className={ctClassNames} {...props}>

--- a/src/scripts/DateInput.tsx
+++ b/src/scripts/DateInput.tsx
@@ -48,8 +48,8 @@ class DatepickerDropdown extends Component<DatepickerDropdownProps> {
     const datepickerClassNames = classnames(
       className,
       'slds-dropdown',
-      align ? `slds-dropdown--${align}` : undefined,
-      vertAlign ? `slds-dropdown--${vertAlign}` : undefined
+      align ? `slds-dropdown_${align}` : undefined,
+      vertAlign ? `slds-dropdown_${vertAlign}` : undefined
     );
     const handleDOMRef = (node: HTMLDivElement) => {
       this.node = node;
@@ -294,7 +294,7 @@ export class DateInput extends Component<DateInputProps, DateInputState> {
     ...props
   }: { inputValue: string | undefined } & InputProps) {
     return (
-      <div className='slds-input-has-icon slds-input-has-icon--right'>
+      <div className='slds-input-has-icon slds-input-has-icon_right'>
         <Input
           inputRef={(node) => (this.input = node)}
           {...props}

--- a/src/scripts/Datepicker.tsx
+++ b/src/scripts/Datepicker.tsx
@@ -234,7 +234,7 @@ export class Datepicker extends Component<DatepickerProps, DatepickerState> {
   renderFilter(cal: Calendar) {
     return (
       <div className='slds-datepicker__filter slds-grid'>
-        <div className='slds-datepicker__filter--month slds-grid slds-grid--align-spread slds-size--2-of-3'>
+        <div className='slds-datepicker__filter_month slds-grid slds-grid_align-spread slds-size_2-of-3'>
           <div className='slds-align-middle'>
             <Button
               className='slds-align-middle'
@@ -259,7 +259,7 @@ export class Datepicker extends Component<DatepickerProps, DatepickerState> {
             />
           </div>
         </div>
-        <div className='slds-size--1-of-3'>
+        <div className='slds-size_1-of-3'>
           <Select value={cal.year} onChange={this.onYearChange.bind(this)}>
             {new Array(11)
               .join('_')

--- a/src/scripts/DropdownButton.tsx
+++ b/src/scripts/DropdownButton.tsx
@@ -51,11 +51,11 @@ export class DropdownButton<EventKey extends Key> extends Component<
     this.state = { opened: false };
     registerStyle('no-hover-popup', [
       [
-        '.slds-dropdown-trigger:hover .slds-dropdown--menu.react-slds-no-hover-popup',
+        '.slds-dropdown-trigger:hover .slds-dropdown_menu.react-slds-no-hover-popup',
         '{ visibility: hidden; opacity: 0; }',
       ],
       [
-        '.slds-dropdown-trigger.react-slds-dropdown-opened .slds-dropdown--menu',
+        '.slds-dropdown-trigger.react-slds-dropdown-opened .slds-dropdown_menu',
         '{ visibility: visible !important; opacity: 1 !important; }',
       ],
     ]);

--- a/src/scripts/DropdownMenu.tsx
+++ b/src/scripts/DropdownMenu.tsx
@@ -24,12 +24,12 @@ export const DropdownMenuHeader: React.FC<DropdownMenuHeaderProps> = ({
 }) => {
   const menuHeaderClass = classnames(
     'slds-dropdown__header',
-    { [`slds-has-divider--${divider}-space`]: divider },
+    { [`slds-has-divider_${divider}-space`]: divider },
     className
   );
   return (
     <div className={menuHeaderClass}>
-      <span className='slds-text-heading--label'>{children}</span>
+      <span className='slds-text-heading_label'>{children}</span>
     </div>
   );
 };
@@ -139,7 +139,7 @@ class DropdownMenuItemInner extends Component<
       'slds-dropdown__item',
       {
         'slds-is-selected': selected,
-        [`slds-has-divider--${divider}-space`]: divider,
+        [`slds-has-divider_${divider}-space`]: divider,
       },
       className
     );
@@ -272,9 +272,9 @@ class DropdownMenuInner<EventKey extends Key> extends Component<
     const dropdownClassNames = classnames(
       className,
       'slds-dropdown',
-      vertAlign ? `slds-dropdown--${vertAlign}` : undefined,
-      align ? `slds-dropdown--${align}` : undefined,
-      size ? `slds-dropdown--${size}` : undefined,
+      vertAlign ? `slds-dropdown_${vertAlign}` : undefined,
+      align ? `slds-dropdown_${align}` : undefined,
+      size ? `slds-dropdown_${size}` : undefined,
       nubbinPosition ? `slds-nubbin_${nubbinPosition}` : undefined,
       { 'react-slds-no-hover-popup': !hoverPopup }
     );

--- a/src/scripts/FieldSet.tsx
+++ b/src/scripts/FieldSet.tsx
@@ -13,7 +13,7 @@ export function FieldSet({
   children,
   ...props
 }: FieldSetProps) {
-  const fsClassNames = classnames(className, 'slds-form--compound');
+  const fsClassNames = classnames(className, 'slds-form_compound');
   return (
     <fieldset className={fsClassNames} {...props}>
       {label ? (

--- a/src/scripts/Form.tsx
+++ b/src/scripts/Form.tsx
@@ -33,7 +33,7 @@ export class Form extends Component<FormProps, {}> {
 
   render() {
     const { className, type, children, ...props } = this.props;
-    const formClassNames = classnames(className, `slds-form--${type}`);
+    const formClassNames = classnames(className, `slds-form_${type}`);
     return (
       <form className={formClassNames} {...props}>
         {React.Children.map(children, this.renderFormElement)}

--- a/src/scripts/FormElement.tsx
+++ b/src/scripts/FormElement.tsx
@@ -31,7 +31,7 @@ export class FormElement extends React.Component<FormElementProps, {}> {
       'slds-form-element',
       {
         'slds-has-error': error,
-        [`slds-size--${cols}-of-${totalCols}`]: typeof totalCols === 'number',
+        [`slds-size_${cols}-of-${totalCols}`]: typeof totalCols === 'number',
       },
       className
     );
@@ -67,7 +67,7 @@ export class FormElement extends React.Component<FormElementProps, {}> {
     const { readOnly } = this.props;
     const formElementControlClassNames = classnames(
       'slds-form-element__control',
-      { 'slds-has-divider--bottom': readOnly }
+      { 'slds-has-divider_bottom': readOnly }
     );
     return (
       <div key='form-element-control' className={formElementControlClassNames}>

--- a/src/scripts/Grid.tsx
+++ b/src/scripts/Grid.tsx
@@ -18,8 +18,8 @@ export const Grid: React.FC<GridProps> = ({
   const gridClassNames = classnames(
     className,
     'slds-grid',
-    vertical ? 'slds-grid--vertical' : null,
-    frame ? 'slds-grid--frame' : null
+    vertical ? 'slds-grid_vertical' : null,
+    frame ? 'slds-grid_frame' : null
   );
   const Tag = tag || 'div';
   return (
@@ -82,7 +82,7 @@ export const Col: React.FC<ColProps> = (props) => {
   const rowClassNames = classnames(
     className,
     padded
-      ? `slds-col--padded${
+      ? `slds-col_padded${
           typeof padded === 'string' && /^(medium|large)$/.test(padded)
             ? `-${padded}`
             : ''
@@ -90,21 +90,21 @@ export const Col: React.FC<ColProps> = (props) => {
       : 'slds-col',
     align ? `slds-align-${align}` : null,
     noFlex ? 'slds-no-flex' : null,
-    order ? `slds-order--${order}` : null,
-    orderSmall ? `slds-small-order--${orderSmall}` : null,
-    orderMedium ? `slds-medium-order--${orderMedium}` : null,
-    orderLarge ? `slds-large-order--${orderLarge}` : null,
+    order ? `slds-order_${order}` : null,
+    orderSmall ? `slds-small-order_${orderSmall}` : null,
+    orderMedium ? `slds-medium-order_${orderMedium}` : null,
+    orderLarge ? `slds-large-order_${orderLarge}` : null,
     cols && totalCols
-      ? `slds-size--${cols}-of-${adjustCols(totalCols, true)}`
+      ? `slds-size_${cols}-of-${adjustCols(totalCols, true)}`
       : null,
     colsSmall && totalColsSmall
-      ? `slds-small-size--${colsSmall}-of-${adjustCols(totalColsSmall)}`
+      ? `slds-small-size_${colsSmall}-of-${adjustCols(totalColsSmall)}`
       : null,
     colsMedium && totalColsMedium
-      ? `slds-medium-size--${colsMedium}-of-${adjustCols(totalColsMedium)}`
+      ? `slds-medium-size_${colsMedium}-of-${adjustCols(totalColsMedium)}`
       : null,
     colsLarge && totalColsLarge
-      ? `slds-large-size--${colsLarge}-of-${adjustCols(totalColsLarge, true)}`
+      ? `slds-large-size_${colsLarge}-of-${adjustCols(totalColsLarge, true)}`
       : null
   );
   return (
@@ -160,12 +160,12 @@ export class Row extends Component<RowProps> {
     const rowClassNames = classnames(
       className,
       'slds-grid',
-      align ? `slds-grid--align-${align}` : null,
+      align ? `slds-grid_align-${align}` : null,
       nowrap ? 'slds-nowrap' : 'slds-wrap',
-      nowrapSmall ? 'slds-nowrap--small' : null,
-      nowrapMedium ? 'slds-nowrap--medium' : null,
-      nowrapLarge ? 'slds-nowrap--large' : null,
-      pullPadded ? 'slds-grid--pull-padded' : null
+      nowrapSmall ? 'slds-nowrap_small' : null,
+      nowrapMedium ? 'slds-nowrap_medium' : null,
+      nowrapLarge ? 'slds-nowrap_large' : null,
+      pullPadded ? 'slds-grid_pull-padded' : null
     );
     const totalCols =
       cols ||

--- a/src/scripts/Icon.tsx
+++ b/src/scripts/Icon.tsx
@@ -225,12 +225,12 @@ export class Icon extends Component<IconProps, IconState> {
     const iconClassNames = classnames(
       {
         'slds-icon': !/slds-button__icon/.test(className),
-        [`slds-icon--${size}`]: /^(x-small|small|medium|large)$/.test(size),
+        [`slds-icon_${size}`]: /^(x-small|small|medium|large)$/.test(size),
         [`slds-icon-text-${textColor}`]:
           /^(default|warning|error)$/.test(textColor || '') && !iconColor,
         [`slds-icon-${iconColor}`]: !container && iconColor,
-        'slds-m-left--x-small': align === 'right',
-        'slds-m-right--x-small': align === 'left',
+        'slds-m-left_x-small': align === 'right',
+        'slds-m-right_x-small': align === 'left',
       },
       className
     );
@@ -266,8 +266,8 @@ export class Icon extends Component<IconProps, IconState> {
       const iconColor = this.getIconColor(fillColor, category, icon);
       const ccontainerClassName = classnames(
         containerClassName,
-        'slds-icon__container',
-        container === 'circle' ? 'slds-icon__container--circle' : null,
+        'slds-icon_container',
+        container === 'circle' ? 'slds-icon_container_circle' : null,
         iconColor ? `slds-icon-${iconColor}` : null
       );
       return (

--- a/src/scripts/Input.tsx
+++ b/src/scripts/Input.tsx
@@ -69,7 +69,7 @@ export class Input extends Component<InputProps> {
     registerStyle('input-icons', [
       // fix styles of double-iconed input
       [
-        '.slds-input-has-icon--left-right .slds-input__icon--right',
+        '.slds-input-has-icon_left-right .slds-input__icon_right',
         '{ left: auto; }',
       ],
     ]);
@@ -96,7 +96,7 @@ export class Input extends Component<InputProps> {
         icon={icon}
         className={classnames(
           'slds-input__icon',
-          `slds-input__icon--${align}`,
+          `slds-input__icon_${align}`,
           'slds-icon-text-default'
         )}
       />
@@ -118,7 +118,7 @@ export class Input extends Component<InputProps> {
     } = props;
     const inputClassNames = classnames(
       className,
-      bare ? 'slds-input--bare' : 'slds-input'
+      bare ? 'slds-input_bare' : 'slds-input'
     );
     return readOnly ? (
       <Text
@@ -178,9 +178,9 @@ export class Input extends Component<InputProps> {
       const wrapperClassName = classnames(
         'slds-form-element__control',
         { 'slds-input-has-icon': iconLeft || iconRight },
-        { 'slds-input-has-icon--left-right': iconLeft && iconRight },
-        { 'slds-input-has-icon--left': iconLeft },
-        { 'slds-input-has-icon--right': iconRight },
+        { 'slds-input-has-icon_left-right': iconLeft && iconRight },
+        { 'slds-input-has-icon_left': iconLeft },
+        { 'slds-input-has-icon_right': iconRight },
         { 'slds-input-has-fixed-addon': addonLeft || addonRight }
       );
       return (

--- a/src/scripts/Lookup.tsx
+++ b/src/scripts/Lookup.tsx
@@ -151,15 +151,15 @@ export class LookupSearch extends Component<LookupSearchProps> {
         '{ padding: 0 0.25rem; }',
       ],
       [
-        '.slds-lookup[data-scope="multi"] .slds-box--border',
+        '.slds-lookup[data-scope="multi"] .slds-box_border',
         '{ background-color: white; }',
       ],
       [
-        '.slds-lookup[data-scope="multi"] .slds-box--border.react-slds-box-disabled',
+        '.slds-lookup[data-scope="multi"] .slds-box_border.react-slds-box-disabled',
         '{ background-color: #e0e5ee; border-color: #a8b7c7; cursor: not-allowed; }',
       ],
       [
-        '.slds-lookup[data-scope="multi"] .slds-box--border .slds-input--bare',
+        '.slds-lookup[data-scope="multi"] .slds-box_border .slds-input_bare',
         '{ height: 2.15rem; width: 100%; }',
       ],
     ]);
@@ -258,7 +258,7 @@ export class LookupSearch extends Component<LookupSearchProps> {
     const searchInputClassNames = classnames(
       'slds-grid',
       'slds-input-has-icon',
-      `slds-input-has-icon--${iconAlign}`,
+      `slds-input-has-icon_${iconAlign}`,
       { 'slds-hide': hidden },
       className
     );
@@ -296,8 +296,8 @@ export class LookupSearch extends Component<LookupSearchProps> {
     const icon = <Icon icon={targetScope.icon || 'none'} size='x-small' />;
     const selectorClassNames = classnames(
       'slds-grid',
-      'slds-grid--align-center',
-      'slds-grid--vertical-align-center',
+      'slds-grid_align-center',
+      'slds-grid_vertical-align-center',
       'react-slds-lookup-scope-selector'
     );
     const { onScopeMenuClick, onScopeSelect } = this.props;
@@ -331,7 +331,7 @@ export class LookupSearch extends Component<LookupSearchProps> {
       const lookupSearchClassNames = classnames(
         'slds-grid',
         'slds-form-element__control',
-        'slds-box--border',
+        'slds-box_border',
         { 'react-slds-box-disabled': disabled },
         { 'slds-hide': hidden }
       );
@@ -468,7 +468,7 @@ class LookupCandidateList<LookupEntry extends Entry> extends Component<
             {icon ? (
               <Icon
                 style={{ minWidth: '1.5rem' }}
-                className='slds-m-right--x-small'
+                className='slds-m-right_x-small'
                 category={category}
                 icon={icon}
                 size='small'

--- a/src/scripts/MediaObject.tsx
+++ b/src/scripts/MediaObject.tsx
@@ -22,7 +22,7 @@ export class MediaObject extends Component<MediaObjectProps, {}> {
     const className = 'slds-media';
     return (
       <div className={className}>
-        {this.renderFigure(figureCenter, 'slds-media__figure_stacked')}
+        {this.renderFigure(figureCenter)}
         {this.renderFigure(figureLeft)}
         <div className='slds-media__body'>{children}</div>
         {this.renderFigure(figureRight, 'slds-media__figure_reverse')}

--- a/src/scripts/MediaObject.tsx
+++ b/src/scripts/MediaObject.tsx
@@ -22,10 +22,10 @@ export class MediaObject extends Component<MediaObjectProps, {}> {
     const className = 'slds-media';
     return (
       <div className={className}>
-        {this.renderFigure(figureCenter, 'slds-media__figure--stacked')}
+        {this.renderFigure(figureCenter, 'slds-media__figure_stacked')}
         {this.renderFigure(figureLeft)}
         <div className='slds-media__body'>{children}</div>
-        {this.renderFigure(figureRight, 'slds-media__figure--reverse')}
+        {this.renderFigure(figureRight, 'slds-media__figure_reverse')}
       </div>
     );
   }

--- a/src/scripts/Modal.tsx
+++ b/src/scripts/Modal.tsx
@@ -29,8 +29,8 @@ export class ModalHeader extends Component<ModalHeaderProps> {
     const hdClassNames = classnames(className, 'slds-modal__header');
     return (
       <div className={hdClassNames} {...props}>
-        <h2 className='slds-text-heading--medium'>{title}</h2>
-        {tagline ? <p className='slds-m-top--x-small'>{tagline}</p> : null}
+        <h2 className='slds-text-heading_medium'>{title}</h2>
+        {tagline ? <p className='slds-m-top_x-small'>{tagline}</p> : null}
         {closeButton ? (
           <Button
             type='icon-inverse'
@@ -76,7 +76,7 @@ export const ModalFooter: React.FC<ModalFooterProps> = ({
   ...props
 }) => {
   const ftClassNames = classnames(className, 'slds-modal__footer', {
-    'slds-modal__footer--directional': directional,
+    'slds-modal__footer_directional': directional,
   });
   return (
     <div className={ftClassNames} {...props}>
@@ -132,7 +132,7 @@ export class Modal extends Component<ModalProps> {
     delete props.onHide;
     const modalClassNames = classnames(className, 'slds-modal', {
       'slds-fade-in-open': opened,
-      'slds-modal--large': size === 'large',
+      'slds-modal_large': size === 'large',
     });
     const backdropClassNames = classnames(className, 'slds-backdrop', {
       'slds-backdrop_open': opened,

--- a/src/scripts/Notification.tsx
+++ b/src/scripts/Notification.tsx
@@ -35,24 +35,24 @@ export const Notification: React.FC<NotificationProps> = (props) => {
   } = props;
   const typeClassName =
     type && NOTIFICATION_TYPES.indexOf(type) >= 0
-      ? `slds-notify--${type}`
+      ? `slds-notify_${type}`
       : null;
   const levelClassName =
     level && NOTIFICATION_LEVELS.indexOf(level) >= 0
-      ? `slds-theme--${level}`
+      ? `slds-theme_${level}`
       : null;
   const alertClassNames = classnames(
     className,
     'slds-notify',
     typeClassName,
     levelClassName,
-    alertTexture ? 'slds-theme--alert-texture' : null
+    alertTexture ? 'slds-theme_alert-texture' : null
   );
 
   const iconEl = icon ? (
     <Icon
       className={
-        type === 'toast' ? 'slds-m-right--small' : 'slds-m-right--x-small'
+        type === 'toast' ? 'slds-m-right_small' : 'slds-m-right_x-small'
       }
       icon={icon}
       size={iconSize}
@@ -82,7 +82,7 @@ export const Notification: React.FC<NotificationProps> = (props) => {
         <div className='slds-notify__content slds-grid'>
           {iconEl}
           <div className='slds-col slds-align-middle'>
-            <h2 className='slds-text-heading--small'>{children}</h2>
+            <h2 className='slds-text-heading_small'>{children}</h2>
           </div>
         </div>
       ) : (

--- a/src/scripts/PageHeader.tsx
+++ b/src/scripts/PageHeader.tsx
@@ -30,7 +30,7 @@ export const PageHeaderDetailLabel: React.FC<PageHeaderDetailLabelProps> = ({
     <Text
       category='title'
       truncate
-      className='slds-m-bottom--xx-small'
+      className='slds-m-bottom_xx-small'
       {...props}
     >
       {children}
@@ -138,7 +138,7 @@ export class PageHeaderHeading extends Component<PageHeaderHeadingProps> {
         : null;
     const titlePart =
       typeof title === 'string' ? (
-        <PageHeaderHeadingTitle className='slds-m-right--small'>
+        <PageHeaderHeadingTitle className='slds-m-right_small'>
           {title}
         </PageHeaderHeadingTitle>
       ) : (
@@ -159,11 +159,7 @@ export class PageHeaderHeading extends Component<PageHeaderHeadingProps> {
       <div>
         {breadCrumbsPart}
         {legend ? (
-          <Text
-            category='title'
-            type='caps'
-            className='slds-line-height--reset'
-          >
+          <Text category='title' type='caps' className='slds-line-height_reset'>
             {legend}
           </Text>
         ) : null}

--- a/src/scripts/Popover.tsx
+++ b/src/scripts/Popover.tsx
@@ -58,11 +58,11 @@ class PopoverInner extends React.Component<PopoverProps & InjectedProps> {
       'slds-popover',
       {
         'slds-hide': hidden,
-        'slds-popover--tooltip': tooltip,
+        'slds-popover_tooltip': tooltip,
       },
-      `slds-nubbin--${nubbinPosition}`,
-      `slds-m-${firstAlign}--small`,
-      theme ? `slds-theme--${theme}` : undefined
+      `slds-nubbin_${nubbinPosition}`,
+      `slds-m-${firstAlign}_small`,
+      theme ? `slds-theme_${theme}` : undefined
     );
     const rootStyle: typeof style = {
       ...style,

--- a/src/scripts/Radio.tsx
+++ b/src/scripts/Radio.tsx
@@ -18,7 +18,7 @@ export const Radio: React.FC<RadioProps> = ({
   return (
     <label className={radioClassNames}>
       <input type='radio' name={name} value={value} {...props} />
-      <span className='slds-radio--faux' />
+      <span className='slds-radio_faux' />
       <span className='slds-form-element__label'>{label}</span>
     </label>
   );

--- a/src/scripts/RadioGroup.tsx
+++ b/src/scripts/RadioGroup.tsx
@@ -52,7 +52,7 @@ export class RadioGroup<
         'slds-is-required': required,
       },
       typeof totalCols === 'number'
-        ? `slds-size--${cols || 1}-of-${totalCols}`
+        ? `slds-size_${cols || 1}-of-${totalCols}`
         : null
     );
     const grpStyles =
@@ -69,7 +69,7 @@ export class RadioGroup<
 
     return (
       <fieldset className={grpClassNames} style={grpStyles} {...props}>
-        <legend className='slds-form-element__label slds-form-element__label--top'>
+        <legend className='slds-form-element__label'>
           {label}
           {required ? <abbr className='slds-required'>*</abbr> : undefined}
         </legend>

--- a/src/scripts/SalesPath.tsx
+++ b/src/scripts/SalesPath.tsx
@@ -22,7 +22,7 @@ class PathItem extends React.Component<PathItemProps> {
     const { className, eventKey, title, completedTitle, type } = this.props;
 
     const pathItemClassName = classnames(
-      'slds-tabs--path__item',
+      'slds-tabs_path__item',
       `slds-is-${type}`,
       className
     );
@@ -33,20 +33,20 @@ class PathItem extends React.Component<PathItemProps> {
     return (
       <li className={pathItemClassName} role='presentation'>
         <a
-          className='slds-tabs--path__link'
+          className='slds-tabs_path__link'
           aria-selected='false'
           tabIndex={tabIndex}
           role='tab'
           aria-live='assertive'
           onClick={this.onItemClick.bind(this, eventKey)}
         >
-          <span className='slds-tabs--path__stage'>
+          <span className='slds-tabs_path__stage'>
             <Icon category='utility' icon='check' size='x-small' />
             {type === 'complete' ? (
               <span className='slds-assistive-text'>{completedText}</span>
             ) : null}
           </span>
-          <span className='slds-tabs--path__title'>{title}</span>
+          <span className='slds-tabs_path__title'>{title}</span>
         </a>
       </li>
     );
@@ -113,10 +113,10 @@ export class SalesPath extends React.Component<SalesPathProps, SalesPathState> {
       this.state.activeKey ||
       this.props.defaultActiveKey;
 
-    const salesPathClassNames = classnames(className, 'slds-tabs--path');
+    const salesPathClassNames = classnames(className, 'slds-tabs_path');
     return (
       <div className={salesPathClassNames} role='application tablist'>
-        <ul className='slds-tabs--path__nav' role='presentation'>
+        <ul className='slds-tabs_path__nav' role='presentation'>
           {this.renderSalesPath(activeKey, children)}
         </ul>
       </div>

--- a/src/scripts/Spinner.tsx
+++ b/src/scripts/Spinner.tsx
@@ -23,8 +23,8 @@ export class Spinner extends React.Component<SpinnerProps, {}> {
     const spinnerClassNames = classnames(
       className,
       'slds-spinner',
-      `slds-spinner--${size}`,
-      type ? `slds-spinner--${type}` : null
+      `slds-spinner_${size}`,
+      type ? `slds-spinner_${type}` : null
     );
 
     return (

--- a/src/scripts/Table.tsx
+++ b/src/scripts/Table.tsx
@@ -22,7 +22,7 @@ export class TableHeader extends Component<TableHeaderProps> {
     let nextChildren: any = [];
 
     const props = {
-      className: 'slds-text-title--caps',
+      className: 'slds-text-title_caps',
     };
 
     React.Children.forEach((children as any).props.children, (child, index) => {
@@ -134,12 +134,12 @@ export const TableHeaderColumn: React.FC<TableHeaderColumnProps> = (props) => {
   } = props;
   const oClassNames = classnames(
     className,
-    'slds-text-title--caps slds-truncate',
+    'slds-text-title_caps slds-truncate',
     {
       'slds-is-sortable': sortable,
       'slds-is-resizable': resizable,
       'slds-is-sorted': sorted,
-      [`slds-text-align--${align}`]: align,
+      [`slds-text-align_${align}`]: align,
     }
   );
 
@@ -157,7 +157,7 @@ export const TableHeaderColumn: React.FC<TableHeaderColumnProps> = (props) => {
               onSort();
             }
           }}
-          className='slds-th__action slds-text-link--reset'
+          className='slds-th__action slds-text-link_reset'
         >
           <span className='slds-assistive-text'>Sort </span>
           <span className='slds-truncate'>{children}</span>
@@ -261,13 +261,13 @@ export class Table extends Component<TableProps> {
 
     const tableClassNames = classnames(
       className,
-      'slds-table slds-table--cell-buffer',
+      'slds-table slds-table_cell-buffer',
       {
-        'slds-table--bordered': bordered,
+        'slds-table_bordered': bordered,
         'slds-no-row-hover': noRowHover,
-        'slds-table--striped': striped,
-        'slds-table--fixed-layout': fixedLayout,
-        'slds-table--col-bordered': verticalBorders,
+        'slds-table_striped': striped,
+        'slds-table_fixed-layout': fixedLayout,
+        'slds-table_col-bordered': verticalBorders,
       }
     );
 

--- a/src/scripts/Tabs.tsx
+++ b/src/scripts/Tabs.tsx
@@ -107,12 +107,12 @@ const TabItem = <EventKey extends Key, EventValueKey extends EventKey>(
   const isActive = eventKey === activeKey;
   const tabItemClassName = classnames(
     { 'slds-tabs__item': !!menuItems },
-    `slds-tabs--${type}__item`,
+    `slds-tabs_${type}__item`,
     'slds-text-heading---label',
     { 'slds-active': isActive },
     { 'react-slds-tab-with-menu': menu || menuItems }
   );
-  const tabLinkClassName = `slds-tabs--${type}__link`;
+  const tabLinkClassName = `slds-tabs_${type}__link`;
   const {
     tabItemRenderer: TabItemRenderer = DefaultTabItemRenderer,
     ...pprops
@@ -177,7 +177,7 @@ const TabNav = <EventKey extends Key, EventValueKey extends EventKey>(
     onTabClick,
     onTabKeyDown,
   } = props;
-  const tabNavClassName = `slds-tabs--${type}__nav`;
+  const tabNavClassName = `slds-tabs_${type}__nav`;
   return (
     <ul className={tabNavClassName} role='tablist'>
       {React.Children.map(tabs, (tab: any) => (
@@ -310,7 +310,7 @@ export class Tabs<
   render() {
     const { className, children } = this.props;
     const type = this.props.type === 'scoped' ? 'scoped' : 'default';
-    const tabsClassNames = classnames(className, `slds-tabs--${type}`);
+    const tabsClassNames = classnames(className, `slds-tabs_${type}`);
     const activeKey =
       typeof this.props.activeKey !== 'undefined'
         ? this.props.activeKey

--- a/src/scripts/Tabs.tsx
+++ b/src/scripts/Tabs.tsx
@@ -108,7 +108,6 @@ const TabItem = <EventKey extends Key, EventValueKey extends EventKey>(
   const tabItemClassName = classnames(
     { 'slds-tabs__item': !!menuItems },
     `slds-tabs_${type}__item`,
-    'slds-text-heading---label',
     { 'slds-active': isActive },
     { 'react-slds-tab-with-menu': menu || menuItems }
   );

--- a/src/scripts/Text.tsx
+++ b/src/scripts/Text.tsx
@@ -23,11 +23,11 @@ export const Text: React.FC<TextProps> = ({
 }) => {
   const textClassNames = classnames(
     {
-      [`slds-text-${category}--${type}`]: type && category,
+      [`slds-text-${category}_${type}`]: type && category,
       [`slds-text-${category}`]: category && !type,
       'slds-truncate': truncate,
-      [`slds-text-align--${align}`]: align,
-      'slds-section-title--divider': section,
+      [`slds-text-align_${align}`]: align,
+      'slds-section-title_divider': section,
     },
     className
   );

--- a/src/scripts/Toggle.tsx
+++ b/src/scripts/Toggle.tsx
@@ -17,11 +17,11 @@ export class Toggle extends Component<ToggleProps> {
   renderToggle({ className, label, ...props }: ToggleProps) {
     const toggleClassNames = classnames(
       className,
-      'slds-checkbox--toggle slds-grid'
+      'slds-checkbox_toggle slds-grid'
     );
     return (
       <label className={toggleClassNames}>
-        <span className='slds-form-element__label slds-m-bottom--none'>
+        <span className='slds-form-element__label slds-m-bottom_none'>
           {label}
         </span>
         <input
@@ -30,10 +30,10 @@ export class Toggle extends Component<ToggleProps> {
           aria-describedby='toggle-desc'
           {...props}
         />
-        <span className='slds-checkbox--faux_container' aria-live='assertive'>
-          <span className='slds-checkbox--faux' />
-          <span className='slds-checkbox--on'>Enabled</span>
-          <span className='slds-checkbox--off'>Disabled</span>
+        <span className='slds-checkbox_faux_container' aria-live='assertive'>
+          <span className='slds-checkbox_faux' />
+          <span className='slds-checkbox_on'>Enabled</span>
+          <span className='slds-checkbox_off'>Disabled</span>
         </span>
       </label>
     );

--- a/src/scripts/Tree.tsx
+++ b/src/scripts/Tree.tsx
@@ -52,7 +52,7 @@ export class Tree extends Component<TreeProps, {}> {
     const treeClassNames = classnames(className, 'slds-tree-container');
     return (
       <div className={treeClassNames} role='application' {...props}>
-        {label ? <h4 className='slds-text-heading--label'>{label}</h4> : null}
+        {label ? <h4 className='slds-text-heading_label'>{label}</h4> : null}
         <ul className='slds-tree' role='tree'>
           {Children.map(children, this.renderTreeNode)}
         </ul>

--- a/src/scripts/TreeNode.tsx
+++ b/src/scripts/TreeNode.tsx
@@ -102,12 +102,12 @@ export class TreeNode extends Component<TreeNodeProps, TreeNodeState> {
           <Spinner
             container={false}
             size='small'
-            className='slds-m-right--x-small'
+            className='slds-m-right_x-small'
             style={{ position: 'static', marginTop: 14, marginLeft: -2 }}
           />
         ) : !leaf ? (
           <Button
-            className='slds-m-right--small'
+            className='slds-m-right_small'
             aria-controls=''
             type='icon-bare'
             icon={icon}

--- a/stories/BadgeStories.tsx
+++ b/stories/BadgeStories.tsx
@@ -3,8 +3,29 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { Badge } from '../src/scripts';
 
-storiesOf('Badge', module).add(
-  'Default',
-  () => <Badge onClick={action('click')}>Badge Label</Badge>,
-  { info: 'Default badge' }
-);
+storiesOf('Badge', module)
+  .add('Default', () => <Badge onClick={action('click')}>Badge Label</Badge>, {
+    info: 'Default badge',
+  })
+  .add(
+    'Shade',
+    () => (
+      <Badge type='shade' onClick={action('click')}>
+        Badge Label
+      </Badge>
+    ),
+    {
+      info: 'Badge with type: shade',
+    }
+  )
+  .add(
+    'Inverse',
+    () => (
+      <Badge type='inverse' onClick={action('click')}>
+        Badge Label
+      </Badge>
+    ),
+    {
+      info: 'Badge with type: inverse',
+    }
+  );

--- a/stories/DatepickerStories.tsx
+++ b/stories/DatepickerStories.tsx
@@ -10,7 +10,7 @@ const TodayButtonExtensionRenderer = (props: any) => {
   const today = moment().format('YYYY-MM-DD');
   return (
     <div style={{ padding: '4px', textAlign: 'center' }}>
-      <Button className='slds-size--1-of-2' onClick={() => onSelect(today)}>
+      <Button className='slds-size_1-of-2' onClick={() => onSelect(today)}>
         Today
       </Button>
     </div>

--- a/stories/IconStories.tsx
+++ b/stories/IconStories.tsx
@@ -79,19 +79,19 @@ storiesOf('Icon', module)
           size='x-small'
           onClick={action('x-small:click')}
         />
-        <span className='slds-p-right--small' />
+        <span className='slds-p-right_small' />
         <Icon
           icon='standard:case'
           size='small'
           onClick={action('small:click')}
         />
-        <span className='slds-p-right--small' />
+        <span className='slds-p-right_small' />
         <Icon
           icon='standard:case'
           size='medium'
           onClick={action('medium:click')}
         />
-        <span className='slds-p-right--small' />
+        <span className='slds-p-right_small' />
         <Icon
           icon='standard:case'
           size='large'
@@ -106,11 +106,7 @@ storiesOf('Icon', module)
     () => (
       <ul className='slds-clearfix'>
         {Icon.ICONS.STANDARD_ICONS.map((icon, i) => (
-          <li
-            key={i}
-            className='slds-p-around--small'
-            style={iconListItemStyle}
-          >
+          <li key={i} className='slds-p-around_small' style={iconListItemStyle}>
             <figure>
               <Icon
                 category='standard'
@@ -130,11 +126,7 @@ storiesOf('Icon', module)
     () => (
       <ul className='slds-clearfix'>
         {Icon.ICONS.CUSTOM_ICONS.map((icon, i) => (
-          <li
-            key={i}
-            className='slds-p-around--small'
-            style={iconListItemStyle}
-          >
+          <li key={i} className='slds-p-around_small' style={iconListItemStyle}>
             <figure>
               <Icon
                 category='custom'
@@ -154,11 +146,7 @@ storiesOf('Icon', module)
     () => (
       <ul className='slds-clearfix'>
         {Icon.ICONS.ACTION_ICONS.map((icon, i) => (
-          <li
-            key={i}
-            className='slds-p-around--small'
-            style={iconListItemStyle}
-          >
+          <li key={i} className='slds-p-around_small' style={iconListItemStyle}>
             <figure>
               <Icon
                 category='action'
@@ -180,11 +168,7 @@ storiesOf('Icon', module)
     () => (
       <ul className='slds-clearfix'>
         {Icon.ICONS.DOCTYPE_ICONS.map((icon, i) => (
-          <li
-            key={i}
-            className='slds-p-around--small'
-            style={iconListItemStyle}
-          >
+          <li key={i} className='slds-p-around_small' style={iconListItemStyle}>
             <figure>
               <Icon
                 category='doctype'
@@ -204,11 +188,7 @@ storiesOf('Icon', module)
     () => (
       <ul className='slds-clearfix'>
         {Icon.ICONS.UTILITY_ICONS.map((icon, i) => (
-          <li
-            key={i}
-            className='slds-p-around--small'
-            style={iconListItemStyle}
-          >
+          <li key={i} className='slds-p-around_small' style={iconListItemStyle}>
             <figure>
               <Icon
                 category='utility'

--- a/stories/ModalStories.tsx
+++ b/stories/ModalStories.tsx
@@ -51,7 +51,7 @@ storiesOf('Modal', module)
             []
           )}
           <Content>
-            <div className='slds-p-around--small'>
+            <div className='slds-p-around_small'>
               <p>
                 Sit nulla est ex deserunt exercitation anim occaecat. Nostrud
                 ullamco deserunt aute id consequat veniam incididunt duis in
@@ -93,7 +93,7 @@ storiesOf('Modal', module)
     () => (
       <Modal opened onHide={action('hide')}>
         <Header title='Default Modal' closeButton />
-        <Content className='slds-p-around--small'>
+        <Content className='slds-p-around_small'>
           <p>
             Sit nulla est ex deserunt exercitation anim occaecat. Nostrud
             ullamco deserunt aute id consequat veniam incididunt duis in sint
@@ -129,7 +129,7 @@ storiesOf('Modal', module)
     () => (
       <Modal opened size='large' onHide={action('hide')}>
         <Header title='Large Size Modal' closeButton />
-        <Content className='slds-p-around--small'>
+        <Content className='slds-p-around_small'>
           <p>
             Sit nulla est ex deserunt exercitation anim occaecat. Nostrud
             ullamco deserunt aute id consequat veniam incididunt duis in sint
@@ -169,7 +169,7 @@ storiesOf('Modal', module)
           tagline='This is a tagline'
           closeButton
         />
-        <Content className='slds-p-around--small'>
+        <Content className='slds-p-around_small'>
           <p>
             Sit nulla est ex deserunt exercitation anim occaecat. Nostrud
             ullamco deserunt aute id consequat veniam incididunt duis in sint
@@ -205,7 +205,7 @@ storiesOf('Modal', module)
     () => (
       <Modal opened onHide={action('hide')}>
         <Header title='Modal with directional footer' closeButton />
-        <Content className='slds-p-around--small'>
+        <Content className='slds-p-around_small'>
           <p>
             Sit nulla est ex deserunt exercitation anim occaecat. Nostrud
             ullamco deserunt aute id consequat veniam incididunt duis in sint
@@ -241,7 +241,7 @@ storiesOf('Modal', module)
     () => (
       <Modal opened onHide={action('hide')}>
         <Header title='Modal Form' closeButton />
-        <Content className='slds-p-around--small'>
+        <Content className='slds-p-around_small'>
           <Form type='compound'>
             <FieldSet label='Name'>
               <Row>

--- a/stories/ModalStories.tsx
+++ b/stories/ModalStories.tsx
@@ -161,6 +161,82 @@ storiesOf('Modal', module)
     }
   )
   .add(
+    'With tagline',
+    () => (
+      <Modal opened onHide={action('hide')}>
+        <Header
+          title='Modal with tagline'
+          tagline='This is a tagline'
+          closeButton
+        />
+        <Content className='slds-p-around--small'>
+          <p>
+            Sit nulla est ex deserunt exercitation anim occaecat. Nostrud
+            ullamco deserunt aute id consequat veniam incididunt duis in sint
+            irure nisi. Mollit officia cillum Lorem ullamco minim nostrud elit
+            officia tempor esse quis. Cillum sunt ad dolore quis aute consequat
+            ipsum magna exercitation reprehenderit magna. Tempor cupidatat
+            consequat elit dolor adipisicing.
+          </p>
+          <p>
+            Dolor eiusmod sunt ex incididunt cillum quis nostrud velit duis sit
+            officia. Lorem aliqua enim laboris do dolor eiusmod officia. Mollit
+            incididunt nisi consectetur esse laborum eiusmod pariatur proident.
+            Eiusmod et adipisicing culpa deserunt nostrud ad veniam nulla aute
+            est. Labore esse esse cupidatat amet velit id elit consequat minim
+            ullamco mollit enim excepteur ea.
+          </p>
+        </Content>
+        <Footer>
+          <Button type='neutral' label='Cancel' />
+          <Button type='brand' label='Done' />
+        </Footer>
+      </Modal>
+    ),
+    {
+      info: {
+        text: 'Modal dialog with tagline',
+        inline: false,
+      },
+    }
+  )
+  .add(
+    'Footer directional',
+    () => (
+      <Modal opened onHide={action('hide')}>
+        <Header title='Modal with directional footer' closeButton />
+        <Content className='slds-p-around--small'>
+          <p>
+            Sit nulla est ex deserunt exercitation anim occaecat. Nostrud
+            ullamco deserunt aute id consequat veniam incididunt duis in sint
+            irure nisi. Mollit officia cillum Lorem ullamco minim nostrud elit
+            officia tempor esse quis. Cillum sunt ad dolore quis aute consequat
+            ipsum magna exercitation reprehenderit magna. Tempor cupidatat
+            consequat elit dolor adipisicing.
+          </p>
+          <p>
+            Dolor eiusmod sunt ex incididunt cillum quis nostrud velit duis sit
+            officia. Lorem aliqua enim laboris do dolor eiusmod officia. Mollit
+            incididunt nisi consectetur esse laborum eiusmod pariatur proident.
+            Eiusmod et adipisicing culpa deserunt nostrud ad veniam nulla aute
+            est. Labore esse esse cupidatat amet velit id elit consequat minim
+            ullamco mollit enim excepteur ea.
+          </p>
+        </Content>
+        <Footer directional>
+          <Button type='neutral' label='Cancel' />
+          <Button type='brand' label='Done' />
+        </Footer>
+      </Modal>
+    ),
+    {
+      info: {
+        text: 'Modal dialog with directional footer',
+        inline: false,
+      },
+    }
+  )
+  .add(
     'Form elements',
     () => (
       <Modal opened onHide={action('hide')}>

--- a/stories/PageHeaderStories.tsx
+++ b/stories/PageHeaderStories.tsx
@@ -124,7 +124,7 @@ storiesOf('PageHeader', module)
             <DropdownButton
               type='icon-more'
               icon='settings'
-              className='slds-m-left--large'
+              className='slds-m-left_large'
             >
               <MenuItem>Menu Item #1</MenuItem>
               <MenuItem>Menu Item #2</MenuItem>

--- a/stories/RadioStories.tsx
+++ b/stories/RadioStories.tsx
@@ -73,4 +73,20 @@ storiesOf('Radio', module)
       </RadioGroup>
     ),
     { info: 'Radio Group control with disabled status' }
+  )
+  .add(
+    'Cols & totalCols',
+    () => (
+      <>
+        <RadioGroup totalCols={3} cols={2} label='Radio Group Label 1'>
+          <Radio label='Radio Label One' value='1' checked />
+          <Radio label='Radio Label Two' value='2' />
+        </RadioGroup>
+        <RadioGroup totalCols={3} cols={1} label='Radio Group Label 2'>
+          <Radio label='Radio Label One' value='1' checked />
+          <Radio label='Radio Label Two' value='2' />
+        </RadioGroup>
+      </>
+    ),
+    { info: 'Radio Group control with `cols` and `totalCols`' }
   );

--- a/stories/TableStories.tsx
+++ b/stories/TableStories.tsx
@@ -134,6 +134,30 @@ storiesOf('Table', module)
     { info: 'Table component with striped row' }
   )
   .add(
+    'With No Row Border',
+    () => (
+      <Table>
+        <TableHeader>
+          <TableRow>
+            {headerNames.map((name) => (
+              <TableHeaderColumn key={name}>{name}</TableHeaderColumn>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {records.map((record) => (
+            <TableRow key={record[0]}>
+              {headerNames.map((name, i) => (
+                <TableRowColumn key={name}>{record[i]}</TableRowColumn>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    ),
+    { info: 'Table component with no row borders' }
+  )
+  .add(
     'With No Row Hover',
     () => (
       <Table bordered noRowHover>

--- a/stories/TabsStories.tsx
+++ b/stories/TabsStories.tsx
@@ -39,7 +39,7 @@ function CustomTabItemContent(props: TabItemRendererProps) {
       }
     >
       <Icon icon={icon} size='small' />
-      <span className='slds-p-horizontal--x-small'>{title}</span>
+      <span className='slds-p-horizontal_x-small'>{title}</span>
     </a>
   );
 }

--- a/test/badge-spec.tsx
+++ b/test/badge-spec.tsx
@@ -24,6 +24,6 @@ describe('Badge', () => {
   it('should render badge based on a type', () => {
     const type = 'shade';
     const wrapper = shallow(<Badge type={type} />);
-    expect(wrapper.hasClass(`slds-theme--${type}`)).toBe(true);
+    expect(wrapper.hasClass(`slds-theme_${type}`)).toBe(true);
   });
 });

--- a/test/breadcrumbs-spec.tsx
+++ b/test/breadcrumbs-spec.tsx
@@ -7,7 +7,7 @@ describe('Crumb', () => {
   it('should have classNames', () => {
     const wrapper = shallow(<Crumb />);
     expect(wrapper.prop('className')).toEqual(
-      'slds-list__item slds-text-heading--label'
+      'slds-list__item slds-text-heading_label'
     );
   });
   it('should render link', () => {

--- a/test/button-spec.tsx
+++ b/test/button-spec.tsx
@@ -42,13 +42,13 @@ describe('Button', () => {
   it('should render button based on a type', () => {
     const type = 'brand';
     const wrapper = shallow(<Button type={type} />);
-    expect(wrapper.hasClass(`slds-button--${type}`)).toBe(true);
+    expect(wrapper.hasClass(`slds-button_${type}`)).toBe(true);
   });
 
   it('should render button based on a size', () => {
     const size = 'small';
     const wrapper = shallow(<Button size={size} />);
-    expect(wrapper.hasClass(`slds-button--${size}`)).toBe(true);
+    expect(wrapper.hasClass(`slds-button_${size}`)).toBe(true);
   });
 
   it('should render button based on htmlType', () => {
@@ -121,18 +121,18 @@ describe('ButtonIcon', () => {
   it('should render button icon based on align', () => {
     const align = 'right';
     const wrapper = shallow(<ButtonIcon align={align} icon='setting' />);
-    expect(wrapper.hasClass(`slds-button__icon--${align}`)).toBe(true);
+    expect(wrapper.hasClass(`slds-button__icon_${align}`)).toBe(true);
   });
 
   it('should render button icon based on size', () => {
     const size = 'medium';
     const wrapper = shallow(<ButtonIcon size={size} icon='setting' />);
-    expect(wrapper.hasClass(`slds-button__icon--${size}`)).toBe(true);
+    expect(wrapper.hasClass(`slds-button__icon_${size}`)).toBe(true);
   });
 
   it('should render button icon inversed', () => {
     const wrapper = shallow(<ButtonIcon inverse icon='setting' />);
-    expect(wrapper.hasClass('slds-button__icon--inverse')).toBe(true);
+    expect(wrapper.hasClass('slds-button__icon_inverse')).toBe(true);
   });
 
   it('should call Icon component with props', () => {

--- a/test/button-spec.tsx
+++ b/test/button-spec.tsx
@@ -45,12 +45,6 @@ describe('Button', () => {
     expect(wrapper.hasClass(`slds-button_${type}`)).toBe(true);
   });
 
-  it('should render button based on a size', () => {
-    const size = 'small';
-    const wrapper = shallow(<Button size={size} />);
-    expect(wrapper.hasClass(`slds-button_${size}`)).toBe(true);
-  });
-
   it('should render button based on htmlType', () => {
     const htmlType = 'button';
     const wrapper = shallow(<Button htmlType={htmlType} />);

--- a/test/icon-spec.tsx
+++ b/test/icon-spec.tsx
@@ -19,7 +19,7 @@ describe('Icon', () => {
   it('should render icon with size', () => {
     const size = 'small';
     const wrapper = shallow(<Icon icon='icon' size={size} />);
-    assert(wrapper.hasClass(`slds-icon--${size}`));
+    assert(wrapper.hasClass(`slds-icon_${size}`));
   });
 
   it('should render icon with category', () => {

--- a/test/notification-spec.tsx
+++ b/test/notification-spec.tsx
@@ -7,7 +7,7 @@ import { Notification, Alert, Toast } from '../src/scripts/Notification';
 describe('Notification', () => {
   it('should render notification with className', () => {
     const wrapper = shallow(<Notification type='alert' />);
-    assert(wrapper.hasClass('slds-notify--alert'));
+    assert(wrapper.hasClass('slds-notify_alert'));
   });
 
   it('should render notification with inner content', () => {
@@ -19,7 +19,7 @@ describe('Notification', () => {
 
   it('should render notification with level', () => {
     const wrapper = shallow(<Notification type='alert' level='success' />);
-    assert(wrapper.hasClass('slds-theme--success'));
+    assert(wrapper.hasClass('slds-theme_success'));
   });
 
   it('should render notification with icon', () => {
@@ -38,11 +38,11 @@ describe('Notification', () => {
 
   it('should render alert', () => {
     const wrapper = mount(<Alert />);
-    assert(wrapper.find('.slds-notify--alert').length === 1);
+    assert(wrapper.find('.slds-notify_alert').length === 1);
   });
 
   it('should render toast', () => {
     const wrapper = mount(<Toast />);
-    assert(wrapper.find('.slds-notify--toast').length === 1);
+    assert(wrapper.find('.slds-notify_toast').length === 1);
   });
 });

--- a/test/storyshots/__snapshots__/storyshots.test.js.snap
+++ b/test/storyshots/__snapshots__/storyshots.test.js.snap
@@ -38,6 +38,82 @@ exports[`Storyshots Badge Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Badge Inverse 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <span
+      className="slds-badge slds-theme_inverse"
+      onClick={[Function]}
+    >
+      Badge Label
+    </span>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Badge with type: inverse
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Badge Shade 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <span
+      className="slds-badge slds-theme_shade"
+      onClick={[Function]}
+    >
+      Badge Label
+    </span>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Badge with type: shade
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots BreadCrumbs Default 1`] = `
 <div
   className="content-wrapper"
@@ -1677,6 +1753,144 @@ exports[`Storyshots Checkbox Required 1`] = `
     >
       <p>
         Checkbox control with required attribute
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Checkbox cols and totalCols 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <fieldset
+      className="slds-form-element slds-size_2-of-3"
+      onChange={[Function]}
+      style={
+        Object {
+          "display": "inline-block",
+        }
+      }
+    >
+      <legend
+        className="slds-form-element__label"
+      >
+        Checkbox Group Label 1
+      </legend>
+      <div
+        className="slds-form-element__control"
+      >
+        <label
+          className="slds-checkbox"
+        >
+          <input
+            disabled={true}
+            type="checkbox"
+            value="1"
+          />
+          <span
+            className="slds-checkbox_faux"
+          />
+          <span
+            className="slds-form-element__label"
+          >
+            Checkbox Label One
+          </span>
+        </label>
+        <label
+          className="slds-checkbox"
+        >
+          <input
+            disabled={true}
+            type="checkbox"
+            value="2"
+          />
+          <span
+            className="slds-checkbox_faux"
+          />
+          <span
+            className="slds-form-element__label"
+          >
+            Checkbox Label Two
+          </span>
+        </label>
+      </div>
+    </fieldset>
+    <fieldset
+      className="slds-form-element slds-size_1-of-3"
+      onChange={[Function]}
+      style={
+        Object {
+          "display": "inline-block",
+        }
+      }
+    >
+      <legend
+        className="slds-form-element__label"
+      >
+        Checkbox Group Label 2
+      </legend>
+      <div
+        className="slds-form-element__control"
+      >
+        <label
+          className="slds-checkbox"
+        >
+          <input
+            disabled={true}
+            type="checkbox"
+            value="1"
+          />
+          <span
+            className="slds-checkbox_faux"
+          />
+          <span
+            className="slds-form-element__label"
+          >
+            Checkbox Label One
+          </span>
+        </label>
+        <label
+          className="slds-checkbox"
+        >
+          <input
+            disabled={true}
+            type="checkbox"
+            value="2"
+          />
+          <span
+            className="slds-checkbox_faux"
+          />
+          <span
+            className="slds-form-element__label"
+          >
+            Checkbox Label Two
+          </span>
+        </label>
+      </div>
+    </fieldset>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Checkbox control with multiple columns
       </p>
     </div>
   </div>
@@ -13227,6 +13441,665 @@ exports[`Storyshots DropdownButton Right icon 1`] = `
 </div>
 `;
 
+exports[`Storyshots DropdownMenu Default 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      className="slds-dropdown slds-dropdown_top slds-dropdown_left react-slds-no-hover-popup"
+      onKeyDown={[Function]}
+      style={
+        Object {
+          "outline": "none",
+        }
+      }
+      tabIndex={-1}
+    >
+      <ul
+        className="slds-dropdown__list"
+        role="menu"
+      />
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Dropdown button with menu items
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots DropdownMenu Hover Popup 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      className="slds-dropdown-trigger slds-button-space-left"
+    >
+      <button
+        aria-haspopup={true}
+        className="slds-button slds-button_neutral"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMenuSelect={[Function]}
+        type="button"
+      >
+        Dropdown Button
+        <svg
+          aria-hidden={true}
+          className="slds-button__icon slds-button__icon_right slds-button__icon_small"
+          pointerEvents="none"
+        >
+          <use
+            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+          />
+        </svg>
+      </button>
+      <div
+        className="slds-dropdown slds-dropdown_top slds-dropdown_left"
+        onBlur={[Function]}
+        onKeyDown={[Function]}
+        style={
+          Object {
+            "outline": "none",
+            "transition": "none",
+          }
+        }
+        tabIndex={-1}
+      >
+        <ul
+          className="slds-dropdown__list"
+          role="menu"
+        >
+          <li
+            className="slds-dropdown__item"
+          >
+            <a
+              className="slds-truncate react-slds-menuitem"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              role="menuitem"
+              tabIndex={0}
+            >
+              <p
+                className="slds-truncate"
+              >
+                Menu Item One
+              </p>
+            </a>
+          </li>
+          <li
+            className="slds-dropdown__item"
+          >
+            <a
+              aria-disabled={true}
+              className="slds-truncate react-slds-menuitem"
+              role="menuitem"
+            >
+              <p
+                className="slds-truncate"
+              >
+                Menu Item Two
+              </p>
+            </a>
+          </li>
+          <li
+            className="slds-dropdown__item"
+          >
+            <a
+              className="slds-truncate react-slds-menuitem"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              role="menuitem"
+              tabIndex={0}
+            >
+              <p
+                className="slds-truncate"
+              >
+                Menu Item Three
+              </p>
+            </a>
+          </li>
+          <li
+            className="slds-dropdown__item slds-has-divider_top-space"
+          >
+            <a
+              className="slds-truncate react-slds-menuitem"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              role="menuitem"
+              tabIndex={0}
+            >
+              <p
+                className="slds-truncate"
+              >
+                Menu Item Four
+              </p>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Dropdown is rendered in hover event
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots DropdownMenu Icon Bare 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      className="slds-dropdown-trigger slds-button-space-left"
+    >
+      <button
+        aria-haspopup={true}
+        className="slds-button slds-button_icon-bare"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMenuSelect={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden={true}
+          className="slds-button__icon"
+          pointerEvents="none"
+        >
+          <use
+            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#settings"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Icon bare dropdown button
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots DropdownMenu Icon More 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      className="slds-dropdown-trigger slds-button-space-left"
+    >
+      <button
+        aria-haspopup={true}
+        className="slds-button slds-button_icon-more"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMenuSelect={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden={true}
+          className="slds-button__icon"
+          pointerEvents="none"
+        >
+          <use
+            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#settings"
+          />
+        </svg>
+        <svg
+          aria-hidden={true}
+          className="slds-button__icon slds-button__icon_right slds-button__icon_x-small"
+          pointerEvents="none"
+        >
+          <use
+            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Icon and more dropdown button
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots DropdownMenu Left icon 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      className="slds-dropdown-trigger slds-button-space-left"
+    >
+      <button
+        aria-haspopup={true}
+        className="slds-button slds-button_icon-border"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMenuSelect={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden={true}
+          className="slds-button__icon"
+          pointerEvents="none"
+        >
+          <use
+            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Dropdown button with icon in left side of menu items
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots DropdownMenu Left/Right icon 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      className="slds-dropdown-trigger slds-button-space-left"
+    >
+      <button
+        aria-haspopup={true}
+        className="slds-button slds-button_icon-border"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMenuSelect={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden={true}
+          className="slds-button__icon"
+          pointerEvents="none"
+        >
+          <use
+            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Dropdown button with icon in left/right side of menu items
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots DropdownMenu Neutral 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      className="slds-dropdown-trigger slds-button-space-left"
+    >
+      <button
+        aria-haspopup={true}
+        className="slds-button slds-button_neutral"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMenuSelect={[Function]}
+        type="button"
+      >
+        Dropdown Button
+        <svg
+          aria-hidden={true}
+          className="slds-button__icon slds-button__icon_right slds-button__icon_small"
+          pointerEvents="none"
+        >
+          <use
+            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Neutral dropdown button
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots DropdownMenu Nubbin in top 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      style={
+        Object {
+          "paddingLeft": 100,
+        }
+      }
+    >
+      <div
+        className="slds-dropdown-trigger slds-button-space-left"
+      >
+        <button
+          aria-haspopup={true}
+          className="slds-button slds-button_icon-container"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onMenuSelect={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden={true}
+            className="slds-button__icon"
+            pointerEvents="none"
+          >
+            <use
+              xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#settings"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Nubbin in top of the menu dropdown
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots DropdownMenu Right aligned menu 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      style={
+        Object {
+          "paddingLeft": 200,
+        }
+      }
+    >
+      <div
+        className="slds-dropdown-trigger slds-button-space-left"
+      >
+        <button
+          aria-haspopup={true}
+          className="slds-button slds-button_icon-border"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onMenuSelect={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden={true}
+            className="slds-button__icon"
+            pointerEvents="none"
+          >
+            <use
+              xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Dropdown
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots DropdownMenu Right icon 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      className="slds-dropdown-trigger slds-button-space-left"
+    >
+      <button
+        aria-haspopup={true}
+        className="slds-button slds-button_icon-border"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMenuSelect={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden={true}
+          className="slds-button__icon"
+          pointerEvents="none"
+        >
+          <use
+            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Dropdown button with icon in right side of menu items
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Form Compound Form 1`] = `
 <div
   className="content-wrapper"
@@ -14572,6 +15445,98 @@ exports[`Storyshots Form Stacked Form 1`] = `
 </div>
 `;
 
+exports[`Storyshots Grid Col padded 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      className="slds-grid slds-grid_vertical"
+    >
+      <div
+        className="slds-grid slds-wrap"
+      >
+        <div
+          className="slds-col_padded"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            A
+          </div>
+        </div>
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            B
+          </div>
+        </div>
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            C
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        rows with 
+        <code>
+          nowrap
+        </code>
+         prop
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Grid Equally Weighted 1`] = `
 <div
   className="content-wrapper"
@@ -14654,6 +15619,654 @@ exports[`Storyshots Grid Equally Weighted 1`] = `
     >
       <p>
         columns with equally weighted
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Grid Frame 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      className="slds-grid slds-grid_vertical slds-grid_frame"
+    >
+      <div
+        className="slds-grid slds-wrap"
+      >
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            A
+          </div>
+        </div>
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            B
+          </div>
+        </div>
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            C
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        grid with frame
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Grid Responsive Col Order 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      className="slds-grid slds-grid_vertical"
+    >
+      <div
+        className="slds-grid slds-wrap"
+      >
+        <div
+          className="slds-col slds-order_3 slds-small-order_1 slds-medium-order_2 slds-large-order_3"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            A
+          </div>
+        </div>
+        <div
+          className="slds-col slds-order_2 slds-small-order_2 slds-medium-order_1 slds-large-order_1"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            B
+          </div>
+        </div>
+        <div
+          className="slds-col slds-order_1 slds-small-order_3 slds-medium-order_3 slds-large-order_2"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            C
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        cols with 
+        <code>
+          order
+        </code>
+         prop
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Grid Responsive Col Size 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      className="slds-grid slds-grid_vertical"
+    >
+      <div
+        className="slds-grid slds-wrap"
+      >
+        <div
+          className="slds-col slds-small-size_2-of-4 slds-medium-size_1-of-4 slds-large-size_1-of-4"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            A
+          </div>
+        </div>
+        <div
+          className="slds-col slds-small-size_1-of-4 slds-medium-size_2-of-4 slds-large-size_1-of-4"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            B
+          </div>
+        </div>
+        <div
+          className="slds-col slds-small-size_1-of-4 slds-medium-size_1-of-4 slds-large-size_2-of-4"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            C
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        responsive layout
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Grid Row Align 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      className="slds-grid slds-grid_vertical"
+    >
+      <div
+        className="slds-grid slds-grid_align-center slds-wrap"
+      >
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            A
+          </div>
+        </div>
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            B
+          </div>
+        </div>
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            C
+          </div>
+        </div>
+      </div>
+      <div
+        className="slds-grid slds-grid_align-space slds-wrap"
+      >
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            A
+          </div>
+        </div>
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            B
+          </div>
+        </div>
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            C
+          </div>
+        </div>
+      </div>
+      <div
+        className="slds-grid slds-grid_align-spread slds-wrap"
+      >
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            A
+          </div>
+        </div>
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            B
+          </div>
+        </div>
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            C
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        rows with 
+        <code>
+          align
+        </code>
+         prop
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Grid Row nowrap 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      className="slds-grid slds-grid_vertical"
+    >
+      <div
+        className="slds-grid slds-wrap slds-nowrap_small"
+      >
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            A
+          </div>
+        </div>
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            B
+          </div>
+        </div>
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            C
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        rows with 
+        <code>
+          nowrap
+        </code>
+         prop
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Grid Row pullPadded 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      className="slds-grid slds-grid_vertical"
+    >
+      <div
+        className="slds-grid slds-wrap slds-grid_pull-padded"
+      >
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            A
+          </div>
+        </div>
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            B
+          </div>
+        </div>
+        <div
+          className="slds-col"
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "#33f",
+                "border": "1px solid #aaf",
+                "color": "#fff",
+                "padding": "12px",
+              }
+            }
+          >
+            C
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        rows with 
+        <code>
+          nowrap
+        </code>
+         prop
       </p>
     </div>
   </div>
@@ -20168,6 +21781,110 @@ exports[`Storyshots Icon Action Icons 1`] = `
     >
       <p>
         Icons in action category
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Icon Align 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      style={
+        Object {
+          "outline": "1px dashed",
+          "width": "100px",
+        }
+      }
+    >
+      <svg
+        aria-hidden={true}
+        className="slds-icon slds-icon-standard-case slds-m-right_x-small"
+        onClick={[Function]}
+      >
+        <use
+          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#case"
+        />
+      </svg>
+      <svg
+        aria-hidden={true}
+        className="slds-icon slds-icon-standard-case slds-m-left_x-small"
+        onClick={[Function]}
+      >
+        <use
+          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#case"
+        />
+      </svg>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Icon with different size (x-small, small, medium, large)
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Icon Container 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <span
+      className="slds-icon_container slds-icon_container_circle slds-icon-standard-case"
+    >
+      <svg
+        aria-hidden={true}
+        className="slds-icon"
+        onClick={[Function]}
+      >
+        <use
+          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#case"
+        />
+      </svg>
+    </span>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Icon with different size (x-small, small, medium, large)
       </p>
     </div>
   </div>
@@ -45268,6 +46985,77 @@ Mollit officia cillum Lorem ullamco minim nostrud elit officia tempor esse quis.
 </div>
 `;
 
+exports[`Storyshots MediaObject Figure - Center 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div
+      className="slds-media"
+    >
+      <div
+        className="slds-media__figure slds-media__figure_stacked"
+      >
+        <img
+          alt="Placeholder"
+          src="/assets/images/avatar1.jpg"
+          style={
+            Object {
+              "height": 100,
+            }
+          }
+        />
+      </div>
+      <div
+        className="slds-media__figure"
+      >
+        <img
+          alt="Placeholder"
+          src="/assets/images/avatar2.jpg"
+          style={
+            Object {
+              "height": 100,
+            }
+          }
+        />
+      </div>
+      <div
+        className="slds-media__body"
+      >
+        <p>
+          Sit nulla est ex deserunt exercitation anim occaecat.
+Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi.
+Mollit officia cillum Lorem ullamco minim nostrud elit officia tempor esse quis.
+        </p>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Media Object with figure in right
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots MediaObject Figure - Reverse 1`] = `
 <div
   className="content-wrapper"
@@ -45551,6 +47339,117 @@ exports[`Storyshots Modal Default 1`] = `
             </button>
             <button
               className="slds-button slds-button--brand"
+              onClick={[Function]}
+              type="button"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        className="slds-backdrop slds-backdrop_open"
+      />
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storyshots Modal Footer directional 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div>
+      <div
+        aria-hidden={false}
+        className="slds-modal slds-fade-in-open"
+        role="dialog"
+      >
+        <div
+          className="slds-modal__container"
+        >
+          <div
+            className="slds-modal__header"
+          >
+            <h2
+              className="slds-text-heading_medium"
+            >
+              Modal with directional footer
+            </h2>
+            <button
+              className="slds-modal__close slds-button slds-button_icon-inverse"
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="slds-button__icon slds-button__icon_large slds-button__icon_inverse"
+                pointerEvents="none"
+              >
+                <use
+                  xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#close"
+                />
+              </svg>
+              <span
+                className="slds-assistive-text"
+              >
+                Close
+              </span>
+            </button>
+          </div>
+          <div
+            className="slds-p-around_small slds-modal__content"
+          >
+            <p>
+              Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi. Mollit officia cillum Lorem ullamco minim nostrud elit officia tempor esse quis. Cillum sunt ad dolore quis aute consequat ipsum magna exercitation reprehenderit magna. Tempor cupidatat consequat elit dolor adipisicing.
+            </p>
+            <p>
+              Dolor eiusmod sunt ex incididunt cillum quis nostrud velit duis sit officia. Lorem aliqua enim laboris do dolor eiusmod officia. Mollit incididunt nisi consectetur esse laborum eiusmod pariatur proident. Eiusmod et adipisicing culpa deserunt nostrud ad veniam nulla aute est. Labore esse esse cupidatat amet velit id elit consequat minim ullamco mollit enim excepteur ea.
+            </p>
+          </div>
+          <div
+            className="slds-modal__footer slds-modal__footer_directional"
+          >
+            <button
+              className="slds-button slds-button_neutral"
+              onClick={[Function]}
+              type="button"
+            >
+              Cancel
+            </button>
+            <button
+              className="slds-button slds-button_brand"
               onClick={[Function]}
               type="button"
             >
@@ -46091,6 +47990,122 @@ exports[`Storyshots Modal Large 1`] = `
             </button>
             <button
               className="slds-button slds-button--brand"
+              onClick={[Function]}
+              type="button"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        className="slds-backdrop slds-backdrop_open"
+      />
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storyshots Modal With tagline 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div>
+      <div
+        aria-hidden={false}
+        className="slds-modal slds-fade-in-open"
+        role="dialog"
+      >
+        <div
+          className="slds-modal__container"
+        >
+          <div
+            className="slds-modal__header"
+          >
+            <h2
+              className="slds-text-heading_medium"
+            >
+              Modal with tagline
+            </h2>
+            <p
+              className="slds-m-top_x-small"
+            >
+              This is a tagline
+            </p>
+            <button
+              className="slds-modal__close slds-button slds-button_icon-inverse"
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="slds-button__icon slds-button__icon_large slds-button__icon_inverse"
+                pointerEvents="none"
+              >
+                <use
+                  xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#close"
+                />
+              </svg>
+              <span
+                className="slds-assistive-text"
+              >
+                Close
+              </span>
+            </button>
+          </div>
+          <div
+            className="slds-p-around_small slds-modal__content"
+          >
+            <p>
+              Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi. Mollit officia cillum Lorem ullamco minim nostrud elit officia tempor esse quis. Cillum sunt ad dolore quis aute consequat ipsum magna exercitation reprehenderit magna. Tempor cupidatat consequat elit dolor adipisicing.
+            </p>
+            <p>
+              Dolor eiusmod sunt ex incididunt cillum quis nostrud velit duis sit officia. Lorem aliqua enim laboris do dolor eiusmod officia. Mollit incididunt nisi consectetur esse laborum eiusmod pariatur proident. Eiusmod et adipisicing culpa deserunt nostrud ad veniam nulla aute est. Labore esse esse cupidatat amet velit id elit consequat minim ullamco mollit enim excepteur ea.
+            </p>
+          </div>
+          <div
+            className="slds-modal__footer"
+          >
+            <button
+              className="slds-button slds-button_neutral"
+              onClick={[Function]}
+              type="button"
+            >
+              Cancel
+            </button>
+            <button
+              className="slds-button slds-button_brand"
               onClick={[Function]}
               type="button"
             >
@@ -51861,6 +53876,147 @@ ea corrupti odit minima?
 </div>
 `;
 
+exports[`Storyshots Radio Cols & totalCols 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <fieldset
+      className="slds-form-element slds-size_2-of-3"
+      style={
+        Object {
+          "display": "inline-block",
+        }
+      }
+    >
+      <legend
+        className="slds-form-element__label"
+      >
+        Radio Group Label 1
+      </legend>
+      <div
+        className="slds-form-element__control"
+      >
+        <label
+          className="slds-radio"
+        >
+          <input
+            checked={true}
+            type="radio"
+            value="1"
+          />
+          <span
+            className="slds-radio_faux"
+          />
+          <span
+            className="slds-form-element__label"
+          >
+            Radio Label One
+          </span>
+        </label>
+        <label
+          className="slds-radio"
+        >
+          <input
+            type="radio"
+            value="2"
+          />
+          <span
+            className="slds-radio_faux"
+          />
+          <span
+            className="slds-form-element__label"
+          >
+            Radio Label Two
+          </span>
+        </label>
+      </div>
+    </fieldset>
+    <fieldset
+      className="slds-form-element slds-size_1-of-3"
+      style={
+        Object {
+          "display": "inline-block",
+        }
+      }
+    >
+      <legend
+        className="slds-form-element__label"
+      >
+        Radio Group Label 2
+      </legend>
+      <div
+        className="slds-form-element__control"
+      >
+        <label
+          className="slds-radio"
+        >
+          <input
+            checked={true}
+            type="radio"
+            value="1"
+          />
+          <span
+            className="slds-radio_faux"
+          />
+          <span
+            className="slds-form-element__label"
+          >
+            Radio Label One
+          </span>
+        </label>
+        <label
+          className="slds-radio"
+        >
+          <input
+            type="radio"
+            value="2"
+          />
+          <span
+            className="slds-radio_faux"
+          />
+          <span
+            className="slds-form-element__label"
+          >
+            Radio Label Two
+          </span>
+        </label>
+      </div>
+    </fieldset>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Radio Group control with 
+        <code>
+          cols
+        </code>
+         and 
+        <code>
+          totalCols
+        </code>
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Radio Controlled with knobs 1`] = `
 <div
   className="content-wrapper"
@@ -53743,6 +55899,405 @@ exports[`Storyshots Spinner Inverse 1`] = `
 </div>
 `;
 
+exports[`Storyshots Table Center Align 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div>
+      <div
+        onScroll={[Function]}
+        style={
+          Object {
+            "overflowX": "auto",
+            "overflowY": "hidden",
+          }
+        }
+      >
+        <table
+          className="slds-table slds-table_cell-buffer slds-table_bordered"
+          style={Object {}}
+        >
+          <thead>
+            <tr
+              className="slds-text-title_caps"
+            >
+              <th
+                className="slds-text-title_caps slds-truncate slds-text-align_center"
+                scope="col"
+                style={
+                  Object {
+                    "minWidth": "auto",
+                  }
+                }
+              >
+                Opportunity Name
+              </th>
+              <th
+                className="slds-text-title_caps slds-truncate slds-text-align_center"
+                scope="col"
+                style={
+                  Object {
+                    "minWidth": "auto",
+                  }
+                }
+              >
+                Account Name
+              </th>
+              <th
+                className="slds-text-title_caps slds-truncate slds-text-align_center"
+                scope="col"
+                style={
+                  Object {
+                    "minWidth": "auto",
+                  }
+                }
+              >
+                Close Date
+              </th>
+              <th
+                className="slds-text-title_caps slds-truncate slds-text-align_center"
+                scope="col"
+                style={
+                  Object {
+                    "minWidth": "auto",
+                  }
+                }
+              >
+                Stage
+              </th>
+              <th
+                className="slds-text-title_caps slds-truncate slds-text-align_center"
+                scope="col"
+                style={
+                  Object {
+                    "minWidth": "auto",
+                  }
+                }
+              >
+                Confidence
+              </th>
+              <th
+                className="slds-text-title_caps slds-truncate slds-text-align_center"
+                scope="col"
+                style={
+                  Object {
+                    "minWidth": "auto",
+                  }
+                }
+              >
+                Amount
+              </th>
+              <th
+                className="slds-text-title_caps slds-truncate slds-text-align_center"
+                scope="col"
+                style={
+                  Object {
+                    "minWidth": "auto",
+                  }
+                }
+              >
+                Contact
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub 1
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                4/14/2015
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Prospecting
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                20%
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                $25k
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                jrogers@cloudhub.com
+              </td>
+            </tr>
+            <tr
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub 2
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                4/14/2015
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Prospecting
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                20%
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                $25k
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                jrogers@cloudhub.com
+              </td>
+            </tr>
+            <tr
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub 3
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                4/14/2015
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Prospecting
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                20%
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                $25k
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                jrogers@cloudhub.com
+              </td>
+            </tr>
+            <tr
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub 4
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                4/14/2015
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Prospecting
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                20%
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                $25k
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                jrogers@cloudhub.com
+              </td>
+            </tr>
+            <tr
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub 5
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                4/14/2015
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Prospecting
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                20%
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                $25k
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                jrogers@cloudhub.com
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Default Table component
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Table Controlled with knobs 1`] = `
 <div
   className="content-wrapper"
@@ -55108,6 +57663,405 @@ exports[`Storyshots Table With Fixed Layout 1`] = `
     >
       <p>
         Table component with fixed layout
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Table With No Row Border 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <div>
+      <div
+        onScroll={[Function]}
+        style={
+          Object {
+            "overflowX": "auto",
+            "overflowY": "hidden",
+          }
+        }
+      >
+        <table
+          className="slds-table slds-table_cell-buffer"
+          style={Object {}}
+        >
+          <thead>
+            <tr
+              className="slds-text-title_caps"
+            >
+              <th
+                className="slds-text-title_caps slds-truncate"
+                scope="col"
+                style={
+                  Object {
+                    "minWidth": "auto",
+                  }
+                }
+              >
+                Opportunity Name
+              </th>
+              <th
+                className="slds-text-title_caps slds-truncate"
+                scope="col"
+                style={
+                  Object {
+                    "minWidth": "auto",
+                  }
+                }
+              >
+                Account Name
+              </th>
+              <th
+                className="slds-text-title_caps slds-truncate"
+                scope="col"
+                style={
+                  Object {
+                    "minWidth": "auto",
+                  }
+                }
+              >
+                Close Date
+              </th>
+              <th
+                className="slds-text-title_caps slds-truncate"
+                scope="col"
+                style={
+                  Object {
+                    "minWidth": "auto",
+                  }
+                }
+              >
+                Stage
+              </th>
+              <th
+                className="slds-text-title_caps slds-truncate"
+                scope="col"
+                style={
+                  Object {
+                    "minWidth": "auto",
+                  }
+                }
+              >
+                Confidence
+              </th>
+              <th
+                className="slds-text-title_caps slds-truncate"
+                scope="col"
+                style={
+                  Object {
+                    "minWidth": "auto",
+                  }
+                }
+              >
+                Amount
+              </th>
+              <th
+                className="slds-text-title_caps slds-truncate"
+                scope="col"
+                style={
+                  Object {
+                    "minWidth": "auto",
+                  }
+                }
+              >
+                Contact
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub 1
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                4/14/2015
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Prospecting
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                20%
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                $25k
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                jrogers@cloudhub.com
+              </td>
+            </tr>
+            <tr
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub 2
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                4/14/2015
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Prospecting
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                20%
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                $25k
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                jrogers@cloudhub.com
+              </td>
+            </tr>
+            <tr
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub 3
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                4/14/2015
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Prospecting
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                20%
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                $25k
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                jrogers@cloudhub.com
+              </td>
+            </tr>
+            <tr
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub 4
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                4/14/2015
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Prospecting
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                20%
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                $25k
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                jrogers@cloudhub.com
+              </td>
+            </tr>
+            <tr
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub 5
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Cloudhub
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                4/14/2015
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                Prospecting
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                20%
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                $25k
+              </td>
+              <td
+                className="slds-truncate"
+                role="gridcell"
+                style={Object {}}
+              >
+                jrogers@cloudhub.com
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Table component with no row borders
       </p>
     </div>
   </div>
@@ -57787,6 +60741,43 @@ exports[`Storyshots Tabs With Dropdown (Scoped) 1`] = `
     >
       <p>
         Scoped tabs with dropdown menu
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Text Default 1`] = `
+<div
+  className="content-wrapper"
+>
+  <div
+    id="story-root"
+    style={Object {}}
+  >
+    <p
+      className="slds-section-title_divider"
+    >
+      Sample Text
+    </p>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "borderRadius": "2px",
+          "color": "black",
+          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
+          "fontSize": "15px",
+          "fontWeight": 300,
+          "lineHeight": 1.45,
+          "padding": "20px 40px 40px",
+        }
+      }
+    >
+      <p>
+        Default Textarea control
       </p>
     </div>
   </div>

--- a/test/storyshots/__snapshots__/storyshots.test.js.snap
+++ b/test/storyshots/__snapshots__/storyshots.test.js.snap
@@ -57785,7 +57785,7 @@ exports[`Storyshots Tabs Controlled with knobs 1`] = `
         role="tablist"
       >
         <li
-          className="slds-tabs_default__item slds-text-heading---label"
+          className="slds-tabs_default__item"
           role="presentation"
         >
           <span
@@ -57804,7 +57804,7 @@ exports[`Storyshots Tabs Controlled with knobs 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs_default__item slds-text-heading---label"
+          className="slds-tabs_default__item"
           role="presentation"
         >
           <span
@@ -57823,7 +57823,7 @@ exports[`Storyshots Tabs Controlled with knobs 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs_default__item slds-text-heading---label"
+          className="slds-tabs_default__item"
           role="presentation"
         >
           <span
@@ -57901,7 +57901,7 @@ exports[`Storyshots Tabs Custom Tab Item 1`] = `
         role="tablist"
       >
         <li
-          className="slds-tabs_default__item slds-text-heading---label slds-active"
+          className="slds-tabs_default__item slds-active"
           role="presentation"
         >
           <a
@@ -57933,7 +57933,7 @@ exports[`Storyshots Tabs Custom Tab Item 1`] = `
           </a>
         </li>
         <li
-          className="slds-tabs_default__item slds-text-heading---label"
+          className="slds-tabs_default__item"
           role="presentation"
         >
           <a
@@ -57965,7 +57965,7 @@ exports[`Storyshots Tabs Custom Tab Item 1`] = `
           </a>
         </li>
         <li
-          className="slds-tabs_default__item slds-text-heading---label"
+          className="slds-tabs_default__item"
           role="presentation"
         >
           <a
@@ -58056,7 +58056,7 @@ exports[`Storyshots Tabs Default 1`] = `
         role="tablist"
       >
         <li
-          className="slds-tabs_default__item slds-text-heading---label slds-active"
+          className="slds-tabs_default__item slds-active"
           role="presentation"
         >
           <span
@@ -58075,7 +58075,7 @@ exports[`Storyshots Tabs Default 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs_default__item slds-text-heading---label"
+          className="slds-tabs_default__item"
           role="presentation"
         >
           <span
@@ -58094,7 +58094,7 @@ exports[`Storyshots Tabs Default 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs_default__item slds-text-heading---label"
+          className="slds-tabs_default__item"
           role="presentation"
         >
           <span
@@ -58172,7 +58172,7 @@ exports[`Storyshots Tabs Scoped 1`] = `
         role="tablist"
       >
         <li
-          className="slds-tabs_scoped__item slds-text-heading---label slds-active"
+          className="slds-tabs_scoped__item slds-active"
           role="presentation"
         >
           <span
@@ -58191,7 +58191,7 @@ exports[`Storyshots Tabs Scoped 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs_scoped__item slds-text-heading---label"
+          className="slds-tabs_scoped__item"
           role="presentation"
         >
           <span
@@ -58210,7 +58210,7 @@ exports[`Storyshots Tabs Scoped 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs_scoped__item slds-text-heading---label"
+          className="slds-tabs_scoped__item"
           role="presentation"
         >
           <span
@@ -58288,7 +58288,7 @@ exports[`Storyshots Tabs With Dropdown (Default) 1`] = `
         role="tablist"
       >
         <li
-          className="slds-tabs__item slds-tabs_default__item slds-text-heading---label slds-active react-slds-tab-with-menu"
+          className="slds-tabs__item slds-tabs_default__item slds-active react-slds-tab-with-menu"
           role="presentation"
         >
           <span
@@ -58329,7 +58329,7 @@ exports[`Storyshots Tabs With Dropdown (Default) 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs__item slds-tabs_default__item slds-text-heading---label react-slds-tab-with-menu"
+          className="slds-tabs__item slds-tabs_default__item react-slds-tab-with-menu"
           role="presentation"
         >
           <span
@@ -58370,7 +58370,7 @@ exports[`Storyshots Tabs With Dropdown (Default) 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs__item slds-tabs_default__item slds-text-heading---label react-slds-tab-with-menu"
+          className="slds-tabs__item slds-tabs_default__item react-slds-tab-with-menu"
           role="presentation"
         >
           <span
@@ -58470,7 +58470,7 @@ exports[`Storyshots Tabs With Dropdown (Scoped) 1`] = `
         role="tablist"
       >
         <li
-          className="slds-tabs__item slds-tabs_scoped__item slds-text-heading---label slds-active react-slds-tab-with-menu"
+          className="slds-tabs__item slds-tabs_scoped__item slds-active react-slds-tab-with-menu"
           role="presentation"
         >
           <span
@@ -58511,7 +58511,7 @@ exports[`Storyshots Tabs With Dropdown (Scoped) 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs__item slds-tabs_scoped__item slds-text-heading---label react-slds-tab-with-menu"
+          className="slds-tabs__item slds-tabs_scoped__item react-slds-tab-with-menu"
           role="presentation"
         >
           <span
@@ -58552,7 +58552,7 @@ exports[`Storyshots Tabs With Dropdown (Scoped) 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs__item slds-tabs_scoped__item slds-text-heading---label react-slds-tab-with-menu"
+          className="slds-tabs__item slds-tabs_scoped__item react-slds-tab-with-menu"
           role="presentation"
         >
           <span

--- a/test/storyshots/__snapshots__/storyshots.test.js.snap
+++ b/test/storyshots/__snapshots__/storyshots.test.js.snap
@@ -127,10 +127,10 @@ exports[`Storyshots BreadCrumbs Default 1`] = `
     >
       <ol
         aria-labelledby="bread-crumb-label"
-        className="slds-breadcrumb slds-list--horizontal"
+        className="slds-breadcrumb slds-list_horizontal"
       >
         <li
-          className="slds-list__item slds-text-heading--label"
+          className="slds-list__item slds-text-heading_label"
           onClick={[Function]}
         >
           <a>
@@ -138,7 +138,7 @@ exports[`Storyshots BreadCrumbs Default 1`] = `
           </a>
         </li>
         <li
-          className="slds-list__item slds-text-heading--label"
+          className="slds-list__item slds-text-heading_label"
           onClick={[Function]}
         >
           <a>
@@ -180,7 +180,7 @@ exports[`Storyshots Button Brand 1`] = `
     style={Object {}}
   >
     <button
-      className="slds-button slds-button--brand"
+      className="slds-button slds-button_brand"
       onClick={[Function]}
       type="button"
     >
@@ -219,7 +219,7 @@ exports[`Storyshots Button Brand disabled 1`] = `
     style={Object {}}
   >
     <button
-      className="slds-button slds-button--brand"
+      className="slds-button slds-button_brand"
       disabled={true}
       onClick={[Function]}
       type="button"
@@ -259,7 +259,7 @@ exports[`Storyshots Button Button Icon 1`] = `
     style={Object {}}
   >
     <button
-      className="slds-button slds-button--icon"
+      className="slds-button slds-button_icon"
       onClick={[Function]}
       type="button"
     >
@@ -306,7 +306,7 @@ exports[`Storyshots Button Button Icon Border 1`] = `
     style={Object {}}
   >
     <button
-      className="slds-button slds-button--icon-border"
+      className="slds-button slds-button_icon-border"
       onClick={[Function]}
       type="button"
     >
@@ -361,7 +361,7 @@ exports[`Storyshots Button Button Icon Border and Filled 1`] = `
       }
     >
       <button
-        className="slds-button slds-button--icon-border-filled"
+        className="slds-button slds-button_icon-border-filled"
         onClick={[Function]}
         type="button"
       >
@@ -409,7 +409,7 @@ exports[`Storyshots Button Button Icon Container 1`] = `
     style={Object {}}
   >
     <button
-      className="slds-button slds-button--icon-container"
+      className="slds-button slds-button_icon-container"
       onClick={[Function]}
       type="button"
     >
@@ -464,13 +464,13 @@ exports[`Storyshots Button Button Icon Inverse 1`] = `
       }
     >
       <button
-        className="slds-button slds-button--icon-inverse"
+        className="slds-button slds-button_icon-inverse"
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="slds-button__icon slds-button__icon--inverse"
+          className="slds-button__icon slds-button__icon_inverse"
           pointerEvents="none"
         >
           <use
@@ -520,14 +520,14 @@ exports[`Storyshots Button Button Icon Inverse in dark background 1`] = `
       }
     >
       <button
-        className="slds-button slds-button--icon-inverse"
+        className="slds-button slds-button_icon-inverse"
         disabled={true}
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="slds-button__icon slds-button__icon--inverse"
+          className="slds-button__icon slds-button__icon_inverse"
           pointerEvents="none"
         >
           <use
@@ -613,7 +613,7 @@ exports[`Storyshots Button Destructive 1`] = `
     style={Object {}}
   >
     <button
-      className="slds-button slds-button--destructive"
+      className="slds-button slds-button_destructive"
       onClick={[Function]}
       type="button"
     >
@@ -652,7 +652,7 @@ exports[`Storyshots Button Destructive disabled 1`] = `
     style={Object {}}
   >
     <button
-      className="slds-button slds-button--destructive"
+      className="slds-button slds-button_destructive"
       disabled={true}
       onClick={[Function]}
       type="button"
@@ -700,7 +700,7 @@ exports[`Storyshots Button Inverse 1`] = `
       }
     >
       <button
-        className="slds-button slds-button--inverse"
+        className="slds-button slds-button_inverse"
         onClick={[Function]}
         type="button"
       >
@@ -748,7 +748,7 @@ exports[`Storyshots Button Inverse Disabled 1`] = `
       }
     >
       <button
-        className="slds-button slds-button--inverse"
+        className="slds-button slds-button_inverse"
         disabled={true}
         onClick={[Function]}
         type="button"
@@ -789,7 +789,7 @@ exports[`Storyshots Button Neutral 1`] = `
     style={Object {}}
   >
     <button
-      className="slds-button slds-button--neutral"
+      className="slds-button slds-button_neutral"
       onClick={[Function]}
       type="button"
     >
@@ -828,7 +828,7 @@ exports[`Storyshots Button Neutral disabled 1`] = `
     style={Object {}}
   >
     <button
-      className="slds-button slds-button--neutral"
+      className="slds-button slds-button_neutral"
       disabled={true}
       onClick={[Function]}
       type="button"
@@ -868,13 +868,13 @@ exports[`Storyshots Button Neutral with left icon 1`] = `
     style={Object {}}
   >
     <button
-      className="slds-button slds-button--neutral"
+      className="slds-button slds-button_neutral"
       onClick={[Function]}
       type="button"
     >
       <svg
         aria-hidden={true}
-        className="slds-button__icon slds-button__icon--left"
+        className="slds-button__icon slds-button__icon_left"
         pointerEvents="none"
       >
         <use
@@ -916,14 +916,14 @@ exports[`Storyshots Button Neutral with right icon 1`] = `
     style={Object {}}
   >
     <button
-      className="slds-button slds-button--neutral"
+      className="slds-button slds-button_neutral"
       onClick={[Function]}
       type="button"
     >
       Button Neutral
       <svg
         aria-hidden={true}
-        className="slds-button__icon slds-button__icon--right"
+        className="slds-button__icon slds-button__icon_right"
         pointerEvents="none"
       >
         <use
@@ -1007,27 +1007,27 @@ exports[`Storyshots ButtonGroup Default 1`] = `
       role="group"
     >
       <button
-        className="slds-button slds-button--neutral"
+        className="slds-button slds-button_neutral"
         onClick={[Function]}
         type="button"
       >
         Refresh
       </button>
       <button
-        className="slds-button slds-button--neutral"
+        className="slds-button slds-button_neutral"
         onClick={[Function]}
         type="button"
       >
         Edit
       </button>
       <button
-        className="slds-button slds-button--neutral"
+        className="slds-button slds-button_neutral"
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="slds-button__icon slds-button__icon--left"
+          className="slds-button__icon slds-button__icon_left"
           pointerEvents="none"
         >
           <use
@@ -1074,28 +1074,28 @@ exports[`Storyshots ButtonGroup Default disalbed 1`] = `
       role="group"
     >
       <button
-        className="slds-button slds-button--neutral"
+        className="slds-button slds-button_neutral"
         onClick={[Function]}
         type="button"
       >
         Refresh
       </button>
       <button
-        className="slds-button slds-button--neutral"
+        className="slds-button slds-button_neutral"
         onClick={[Function]}
         type="button"
       >
         Edit
       </button>
       <button
-        className="slds-button slds-button--neutral"
+        className="slds-button slds-button_neutral"
         disabled={true}
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="slds-button__icon slds-button__icon--left"
+          className="slds-button__icon slds-button__icon_left"
           pointerEvents="none"
         >
           <use
@@ -1150,27 +1150,27 @@ exports[`Storyshots ButtonGroup Inverse 1`] = `
         role="group"
       >
         <button
-          className="slds-button slds-button--inverse"
+          className="slds-button slds-button_inverse"
           onClick={[Function]}
           type="button"
         >
           Refresh
         </button>
         <button
-          className="slds-button slds-button--inverse"
+          className="slds-button slds-button_inverse"
           onClick={[Function]}
           type="button"
         >
           Edit
         </button>
         <button
-          className="slds-button slds-button--inverse"
+          className="slds-button slds-button_inverse"
           onClick={[Function]}
           type="button"
         >
           <svg
             aria-hidden={true}
-            className="slds-button__icon slds-button__icon--left slds-button__icon--inverse"
+            className="slds-button__icon slds-button__icon_left slds-button__icon_inverse"
             pointerEvents="none"
           >
             <use
@@ -1196,7 +1196,7 @@ exports[`Storyshots ButtonGroup Inverse 1`] = `
             />
             <button
               aria-haspopup={true}
-              className="slds-button slds-button--icon-border-inverse"
+              className="slds-button slds-button_icon-border-inverse"
               onBlur={[Function]}
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -1205,7 +1205,7 @@ exports[`Storyshots ButtonGroup Inverse 1`] = `
             >
               <svg
                 aria-hidden={true}
-                className="slds-button__icon slds-button__icon--inverse"
+                className="slds-button__icon slds-button__icon_inverse"
                 pointerEvents="none"
               >
                 <use
@@ -1254,27 +1254,27 @@ exports[`Storyshots ButtonGroup More 1`] = `
       role="group"
     >
       <button
-        className="slds-button slds-button--neutral"
+        className="slds-button slds-button_neutral"
         onClick={[Function]}
         type="button"
       >
         Refresh
       </button>
       <button
-        className="slds-button slds-button--neutral"
+        className="slds-button slds-button_neutral"
         onClick={[Function]}
         type="button"
       >
         Edit
       </button>
       <button
-        className="slds-button slds-button--neutral"
+        className="slds-button slds-button_neutral"
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="slds-button__icon slds-button__icon--left"
+          className="slds-button__icon slds-button__icon_left"
           pointerEvents="none"
         >
           <use
@@ -1300,7 +1300,7 @@ exports[`Storyshots ButtonGroup More 1`] = `
           />
           <button
             aria-haspopup={true}
-            className="slds-button slds-button--icon-border"
+            className="slds-button slds-button_icon-border"
             onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1357,7 +1357,7 @@ exports[`Storyshots Checkbox Controlled with knobs 1`] = `
       onChange={[Function]}
     >
       <legend
-        className="slds-form-element__label slds-form-element__label--top"
+        className="slds-form-element__label"
       >
         Checkbox Group Label
       </legend>
@@ -1374,7 +1374,7 @@ exports[`Storyshots Checkbox Controlled with knobs 1`] = `
             value="1"
           />
           <span
-            className="slds-checkbox--faux"
+            className="slds-checkbox_faux"
           />
           <span
             className="slds-form-element__label"
@@ -1392,7 +1392,7 @@ exports[`Storyshots Checkbox Controlled with knobs 1`] = `
             value="2"
           />
           <span
-            className="slds-checkbox--faux"
+            className="slds-checkbox_faux"
           />
           <span
             className="slds-form-element__label"
@@ -1439,7 +1439,7 @@ exports[`Storyshots Checkbox Default 1`] = `
       onChange={[Function]}
     >
       <legend
-        className="slds-form-element__label slds-form-element__label--top"
+        className="slds-form-element__label"
       >
         Checkbox Group Label
       </legend>
@@ -1455,7 +1455,7 @@ exports[`Storyshots Checkbox Default 1`] = `
             value="1"
           />
           <span
-            className="slds-checkbox--faux"
+            className="slds-checkbox_faux"
           />
           <span
             className="slds-form-element__label"
@@ -1472,7 +1472,7 @@ exports[`Storyshots Checkbox Default 1`] = `
             value="2"
           />
           <span
-            className="slds-checkbox--faux"
+            className="slds-checkbox_faux"
           />
           <span
             className="slds-form-element__label"
@@ -1519,7 +1519,7 @@ exports[`Storyshots Checkbox Disabled 1`] = `
       onChange={[Function]}
     >
       <legend
-        className="slds-form-element__label slds-form-element__label--top"
+        className="slds-form-element__label"
       >
         Checkbox Group Label
       </legend>
@@ -1535,7 +1535,7 @@ exports[`Storyshots Checkbox Disabled 1`] = `
             value="1"
           />
           <span
-            className="slds-checkbox--faux"
+            className="slds-checkbox_faux"
           />
           <span
             className="slds-form-element__label"
@@ -1552,7 +1552,7 @@ exports[`Storyshots Checkbox Disabled 1`] = `
             value="2"
           />
           <span
-            className="slds-checkbox--faux"
+            className="slds-checkbox_faux"
           />
           <span
             className="slds-form-element__label"
@@ -1599,7 +1599,7 @@ exports[`Storyshots Checkbox Error 1`] = `
       onChange={[Function]}
     >
       <legend
-        className="slds-form-element__label slds-form-element__label--top"
+        className="slds-form-element__label"
       >
         Checkbox Group Label
         <abbr
@@ -1620,7 +1620,7 @@ exports[`Storyshots Checkbox Error 1`] = `
             value="1"
           />
           <span
-            className="slds-checkbox--faux"
+            className="slds-checkbox_faux"
           />
           <span
             className="slds-form-element__label"
@@ -1636,7 +1636,7 @@ exports[`Storyshots Checkbox Error 1`] = `
             value="2"
           />
           <span
-            className="slds-checkbox--faux"
+            className="slds-checkbox_faux"
           />
           <span
             className="slds-form-element__label"
@@ -1688,7 +1688,7 @@ exports[`Storyshots Checkbox Required 1`] = `
       onChange={[Function]}
     >
       <legend
-        className="slds-form-element__label slds-form-element__label--top"
+        className="slds-form-element__label"
       >
         Checkbox Group Label
         <abbr
@@ -1709,7 +1709,7 @@ exports[`Storyshots Checkbox Required 1`] = `
             value="1"
           />
           <span
-            className="slds-checkbox--faux"
+            className="slds-checkbox_faux"
           />
           <span
             className="slds-form-element__label"
@@ -1725,7 +1725,7 @@ exports[`Storyshots Checkbox Required 1`] = `
             value="2"
           />
           <span
-            className="slds-checkbox--faux"
+            className="slds-checkbox_faux"
           />
           <span
             className="slds-form-element__label"
@@ -1759,144 +1759,6 @@ exports[`Storyshots Checkbox Required 1`] = `
 </div>
 `;
 
-exports[`Storyshots Checkbox cols and totalCols 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <fieldset
-      className="slds-form-element slds-size_2-of-3"
-      onChange={[Function]}
-      style={
-        Object {
-          "display": "inline-block",
-        }
-      }
-    >
-      <legend
-        className="slds-form-element__label"
-      >
-        Checkbox Group Label 1
-      </legend>
-      <div
-        className="slds-form-element__control"
-      >
-        <label
-          className="slds-checkbox"
-        >
-          <input
-            disabled={true}
-            type="checkbox"
-            value="1"
-          />
-          <span
-            className="slds-checkbox_faux"
-          />
-          <span
-            className="slds-form-element__label"
-          >
-            Checkbox Label One
-          </span>
-        </label>
-        <label
-          className="slds-checkbox"
-        >
-          <input
-            disabled={true}
-            type="checkbox"
-            value="2"
-          />
-          <span
-            className="slds-checkbox_faux"
-          />
-          <span
-            className="slds-form-element__label"
-          >
-            Checkbox Label Two
-          </span>
-        </label>
-      </div>
-    </fieldset>
-    <fieldset
-      className="slds-form-element slds-size_1-of-3"
-      onChange={[Function]}
-      style={
-        Object {
-          "display": "inline-block",
-        }
-      }
-    >
-      <legend
-        className="slds-form-element__label"
-      >
-        Checkbox Group Label 2
-      </legend>
-      <div
-        className="slds-form-element__control"
-      >
-        <label
-          className="slds-checkbox"
-        >
-          <input
-            disabled={true}
-            type="checkbox"
-            value="1"
-          />
-          <span
-            className="slds-checkbox_faux"
-          />
-          <span
-            className="slds-form-element__label"
-          >
-            Checkbox Label One
-          </span>
-        </label>
-        <label
-          className="slds-checkbox"
-        >
-          <input
-            disabled={true}
-            type="checkbox"
-            value="2"
-          />
-          <span
-            className="slds-checkbox_faux"
-          />
-          <span
-            className="slds-form-element__label"
-          >
-            Checkbox Label Two
-          </span>
-        </label>
-      </div>
-    </fieldset>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        Checkbox control with multiple columns
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Storyshots DateInput Controlled with knobs 1`] = `
 <div
   className="content-wrapper"
@@ -1921,7 +1783,7 @@ exports[`Storyshots DateInput Controlled with knobs 1`] = `
           className="slds-dropdown-trigger"
         >
           <div
-            className="slds-input-has-icon slds-input-has-icon--right"
+            className="slds-input-has-icon slds-input-has-icon_right"
           >
             <input
               className="slds-input"
@@ -1931,7 +1793,7 @@ exports[`Storyshots DateInput Controlled with knobs 1`] = `
               onKeyDown={[Function]}
             />
             <button
-              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
               onBlur={[Function]}
               onClick={[Function]}
               tabIndex={-1}
@@ -1999,7 +1861,7 @@ exports[`Storyshots DateInput Default 1`] = `
           className="slds-dropdown-trigger"
         >
           <div
-            className="slds-input-has-icon slds-input-has-icon--right"
+            className="slds-input-has-icon slds-input-has-icon_right"
           >
             <input
               className="slds-input"
@@ -2010,7 +1872,7 @@ exports[`Storyshots DateInput Default 1`] = `
               value="04/13/2016"
             />
             <button
-              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
               onBlur={[Function]}
               onClick={[Function]}
               tabIndex={-1}
@@ -2029,7 +1891,7 @@ exports[`Storyshots DateInput Default 1`] = `
           </div>
           <div
             aria-hidden={false}
-            className="slds-datepicker slds-dropdown slds-dropdown--left slds-dropdown--top"
+            className="slds-datepicker slds-dropdown slds-dropdown_left slds-dropdown_top"
             onBlur={[Function]}
             onKeyDown={[Function]}
             tabIndex={-1}
@@ -2038,13 +1900,13 @@ exports[`Storyshots DateInput Default 1`] = `
               className="slds-datepicker__filter slds-grid"
             >
               <div
-                className="slds-datepicker__filter--month slds-grid slds-grid--align-spread slds-size--2-of-3"
+                className="slds-datepicker__filter_month slds-grid slds-grid_align-spread slds-size_2-of-3"
               >
                 <div
                   className="slds-align-middle"
                 >
                   <button
-                    className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                    className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                     onClick={[Function]}
                     type="button"
                   >
@@ -2073,7 +1935,7 @@ exports[`Storyshots DateInput Default 1`] = `
                   className="slds-align-middle"
                 >
                   <button
-                    className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                    className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                     onClick={[Function]}
                     type="button"
                   >
@@ -2095,7 +1957,7 @@ exports[`Storyshots DateInput Default 1`] = `
                 </div>
               </div>
               <div
-                className="slds-size--1-of-3"
+                className="slds-size_1-of-3"
               >
                 <select
                   className="slds-select"
@@ -2914,7 +2776,7 @@ exports[`Storyshots DateInput Disabled 1`] = `
           className="slds-dropdown-trigger"
         >
           <div
-            className="slds-input-has-icon slds-input-has-icon--right"
+            className="slds-input-has-icon slds-input-has-icon_right"
           >
             <input
               className="slds-input"
@@ -2926,7 +2788,7 @@ exports[`Storyshots DateInput Disabled 1`] = `
               value="04/13/2016"
             />
             <button
-              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
               disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
@@ -2946,7 +2808,7 @@ exports[`Storyshots DateInput Disabled 1`] = `
           </div>
           <div
             aria-hidden={false}
-            className="slds-datepicker slds-dropdown slds-dropdown--left slds-dropdown--top"
+            className="slds-datepicker slds-dropdown slds-dropdown_left slds-dropdown_top"
             onBlur={[Function]}
             onKeyDown={[Function]}
             tabIndex={-1}
@@ -2955,13 +2817,13 @@ exports[`Storyshots DateInput Disabled 1`] = `
               className="slds-datepicker__filter slds-grid"
             >
               <div
-                className="slds-datepicker__filter--month slds-grid slds-grid--align-spread slds-size--2-of-3"
+                className="slds-datepicker__filter_month slds-grid slds-grid_align-spread slds-size_2-of-3"
               >
                 <div
                   className="slds-align-middle"
                 >
                   <button
-                    className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                    className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                     onClick={[Function]}
                     type="button"
                   >
@@ -2990,7 +2852,7 @@ exports[`Storyshots DateInput Disabled 1`] = `
                   className="slds-align-middle"
                 >
                   <button
-                    className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                    className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                     onClick={[Function]}
                     type="button"
                   >
@@ -3012,7 +2874,7 @@ exports[`Storyshots DateInput Disabled 1`] = `
                 </div>
               </div>
               <div
-                className="slds-size--1-of-3"
+                className="slds-size_1-of-3"
               >
                 <select
                   className="slds-select"
@@ -3836,7 +3698,7 @@ exports[`Storyshots DateInput Error 1`] = `
           className="slds-dropdown-trigger"
         >
           <div
-            className="slds-input-has-icon slds-input-has-icon--right"
+            className="slds-input-has-icon slds-input-has-icon_right"
           >
             <input
               className="slds-input"
@@ -3847,7 +3709,7 @@ exports[`Storyshots DateInput Error 1`] = `
               value="04/13/2016"
             />
             <button
-              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
               onBlur={[Function]}
               onClick={[Function]}
               tabIndex={-1}
@@ -3866,7 +3728,7 @@ exports[`Storyshots DateInput Error 1`] = `
           </div>
           <div
             aria-hidden={false}
-            className="slds-datepicker slds-dropdown slds-dropdown--left slds-dropdown--top"
+            className="slds-datepicker slds-dropdown slds-dropdown_left slds-dropdown_top"
             onBlur={[Function]}
             onKeyDown={[Function]}
             tabIndex={-1}
@@ -3875,13 +3737,13 @@ exports[`Storyshots DateInput Error 1`] = `
               className="slds-datepicker__filter slds-grid"
             >
               <div
-                className="slds-datepicker__filter--month slds-grid slds-grid--align-spread slds-size--2-of-3"
+                className="slds-datepicker__filter_month slds-grid slds-grid_align-spread slds-size_2-of-3"
               >
                 <div
                   className="slds-align-middle"
                 >
                   <button
-                    className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                    className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                     onClick={[Function]}
                     type="button"
                   >
@@ -3910,7 +3772,7 @@ exports[`Storyshots DateInput Error 1`] = `
                   className="slds-align-middle"
                 >
                   <button
-                    className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                    className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                     onClick={[Function]}
                     type="button"
                   >
@@ -3932,7 +3794,7 @@ exports[`Storyshots DateInput Error 1`] = `
                 </div>
               </div>
               <div
-                className="slds-size--1-of-3"
+                className="slds-size_1-of-3"
               >
                 <select
                   className="slds-select"
@@ -4756,7 +4618,7 @@ exports[`Storyshots DateInput Include time data 1`] = `
           className="slds-dropdown-trigger"
         >
           <div
-            className="slds-input-has-icon slds-input-has-icon--right"
+            className="slds-input-has-icon slds-input-has-icon_right"
           >
             <input
               className="slds-input"
@@ -4767,7 +4629,7 @@ exports[`Storyshots DateInput Include time data 1`] = `
               value="2016/04/13 23:42:56"
             />
             <button
-              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
               onBlur={[Function]}
               onClick={[Function]}
               tabIndex={-1}
@@ -4786,7 +4648,7 @@ exports[`Storyshots DateInput Include time data 1`] = `
           </div>
           <div
             aria-hidden={false}
-            className="slds-datepicker slds-dropdown slds-dropdown--left slds-dropdown--top"
+            className="slds-datepicker slds-dropdown slds-dropdown_left slds-dropdown_top"
             onBlur={[Function]}
             onKeyDown={[Function]}
             tabIndex={-1}
@@ -4795,13 +4657,13 @@ exports[`Storyshots DateInput Include time data 1`] = `
               className="slds-datepicker__filter slds-grid"
             >
               <div
-                className="slds-datepicker__filter--month slds-grid slds-grid--align-spread slds-size--2-of-3"
+                className="slds-datepicker__filter_month slds-grid slds-grid_align-spread slds-size_2-of-3"
               >
                 <div
                   className="slds-align-middle"
                 >
                   <button
-                    className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                    className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                     onClick={[Function]}
                     type="button"
                   >
@@ -4830,7 +4692,7 @@ exports[`Storyshots DateInput Include time data 1`] = `
                   className="slds-align-middle"
                 >
                   <button
-                    className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                    className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                     onClick={[Function]}
                     type="button"
                   >
@@ -4852,7 +4714,7 @@ exports[`Storyshots DateInput Include time data 1`] = `
                 </div>
               </div>
               <div
-                className="slds-size--1-of-3"
+                className="slds-size_1-of-3"
               >
                 <select
                   className="slds-select"
@@ -5676,7 +5538,7 @@ exports[`Storyshots DateInput Required 1`] = `
           className="slds-dropdown-trigger"
         >
           <div
-            className="slds-input-has-icon slds-input-has-icon--right"
+            className="slds-input-has-icon slds-input-has-icon_right"
           >
             <input
               className="slds-input"
@@ -5687,7 +5549,7 @@ exports[`Storyshots DateInput Required 1`] = `
               value="04/13/2016"
             />
             <button
-              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
               onBlur={[Function]}
               onClick={[Function]}
               tabIndex={-1}
@@ -5706,7 +5568,7 @@ exports[`Storyshots DateInput Required 1`] = `
           </div>
           <div
             aria-hidden={false}
-            className="slds-datepicker slds-dropdown slds-dropdown--left slds-dropdown--top"
+            className="slds-datepicker slds-dropdown slds-dropdown_left slds-dropdown_top"
             onBlur={[Function]}
             onKeyDown={[Function]}
             tabIndex={-1}
@@ -5715,13 +5577,13 @@ exports[`Storyshots DateInput Required 1`] = `
               className="slds-datepicker__filter slds-grid"
             >
               <div
-                className="slds-datepicker__filter--month slds-grid slds-grid--align-spread slds-size--2-of-3"
+                className="slds-datepicker__filter_month slds-grid slds-grid_align-spread slds-size_2-of-3"
               >
                 <div
                   className="slds-align-middle"
                 >
                   <button
-                    className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                    className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                     onClick={[Function]}
                     type="button"
                   >
@@ -5750,7 +5612,7 @@ exports[`Storyshots DateInput Required 1`] = `
                   className="slds-align-middle"
                 >
                   <button
-                    className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                    className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                     onClick={[Function]}
                     type="button"
                   >
@@ -5772,7 +5634,7 @@ exports[`Storyshots DateInput Required 1`] = `
                 </div>
               </div>
               <div
-                className="slds-size--1-of-3"
+                className="slds-size_1-of-3"
               >
                 <select
                   className="slds-select"
@@ -6591,7 +6453,7 @@ exports[`Storyshots DateInput With date format 1`] = `
           className="slds-dropdown-trigger"
         >
           <div
-            className="slds-input-has-icon slds-input-has-icon--right"
+            className="slds-input-has-icon slds-input-has-icon_right"
           >
             <input
               className="slds-input"
@@ -6602,7 +6464,7 @@ exports[`Storyshots DateInput With date format 1`] = `
               value="2016.04.13"
             />
             <button
-              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
               onBlur={[Function]}
               onClick={[Function]}
               tabIndex={-1}
@@ -6621,7 +6483,7 @@ exports[`Storyshots DateInput With date format 1`] = `
           </div>
           <div
             aria-hidden={false}
-            className="slds-datepicker slds-dropdown slds-dropdown--left slds-dropdown--top"
+            className="slds-datepicker slds-dropdown slds-dropdown_left slds-dropdown_top"
             onBlur={[Function]}
             onKeyDown={[Function]}
             tabIndex={-1}
@@ -6630,13 +6492,13 @@ exports[`Storyshots DateInput With date format 1`] = `
               className="slds-datepicker__filter slds-grid"
             >
               <div
-                className="slds-datepicker__filter--month slds-grid slds-grid--align-spread slds-size--2-of-3"
+                className="slds-datepicker__filter_month slds-grid slds-grid_align-spread slds-size_2-of-3"
               >
                 <div
                   className="slds-align-middle"
                 >
                   <button
-                    className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                    className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                     onClick={[Function]}
                     type="button"
                   >
@@ -6665,7 +6527,7 @@ exports[`Storyshots DateInput With date format 1`] = `
                   className="slds-align-middle"
                 >
                   <button
-                    className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                    className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                     onClick={[Function]}
                     type="button"
                   >
@@ -6687,7 +6549,7 @@ exports[`Storyshots DateInput With date format 1`] = `
                 </div>
               </div>
               <div
-                className="slds-size--1-of-3"
+                className="slds-size_1-of-3"
               >
                 <select
                   className="slds-select"
@@ -7506,7 +7368,7 @@ exports[`Storyshots DateInput With min/max date 1`] = `
           className="slds-dropdown-trigger"
         >
           <div
-            className="slds-input-has-icon slds-input-has-icon--right"
+            className="slds-input-has-icon slds-input-has-icon_right"
           >
             <input
               className="slds-input"
@@ -7517,7 +7379,7 @@ exports[`Storyshots DateInput With min/max date 1`] = `
               value="04/13/2016"
             />
             <button
-              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
               onBlur={[Function]}
               onClick={[Function]}
               tabIndex={-1}
@@ -7536,7 +7398,7 @@ exports[`Storyshots DateInput With min/max date 1`] = `
           </div>
           <div
             aria-hidden={false}
-            className="slds-datepicker slds-dropdown slds-dropdown--left slds-dropdown--top"
+            className="slds-datepicker slds-dropdown slds-dropdown_left slds-dropdown_top"
             onBlur={[Function]}
             onKeyDown={[Function]}
             tabIndex={-1}
@@ -7545,13 +7407,13 @@ exports[`Storyshots DateInput With min/max date 1`] = `
               className="slds-datepicker__filter slds-grid"
             >
               <div
-                className="slds-datepicker__filter--month slds-grid slds-grid--align-spread slds-size--2-of-3"
+                className="slds-datepicker__filter_month slds-grid slds-grid_align-spread slds-size_2-of-3"
               >
                 <div
                   className="slds-align-middle"
                 >
                   <button
-                    className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                    className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                     onClick={[Function]}
                     type="button"
                   >
@@ -7580,7 +7442,7 @@ exports[`Storyshots DateInput With min/max date 1`] = `
                   className="slds-align-middle"
                 >
                   <button
-                    className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                    className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                     onClick={[Function]}
                     type="button"
                   >
@@ -7602,7 +7464,7 @@ exports[`Storyshots DateInput With min/max date 1`] = `
                 </div>
               </div>
               <div
-                className="slds-size--1-of-3"
+                className="slds-size_1-of-3"
               >
                 <select
                   className="slds-select"
@@ -8372,13 +8234,13 @@ exports[`Storyshots Datepicker Controlled with knobs 1`] = `
           className="slds-datepicker__filter slds-grid"
         >
           <div
-            className="slds-datepicker__filter--month slds-grid slds-grid--align-spread slds-size--2-of-3"
+            className="slds-datepicker__filter_month slds-grid slds-grid_align-spread slds-size_2-of-3"
           >
             <div
               className="slds-align-middle"
             >
               <button
-                className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                 onClick={[Function]}
                 type="button"
               >
@@ -8407,7 +8269,7 @@ exports[`Storyshots Datepicker Controlled with knobs 1`] = `
               className="slds-align-middle"
             >
               <button
-                className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                 onClick={[Function]}
                 type="button"
               >
@@ -8429,7 +8291,7 @@ exports[`Storyshots Datepicker Controlled with knobs 1`] = `
             </div>
           </div>
           <div
-            className="slds-size--1-of-3"
+            className="slds-size_1-of-3"
           >
             <select
               className="slds-select"
@@ -9251,13 +9113,13 @@ exports[`Storyshots Datepicker Default 1`] = `
           className="slds-datepicker__filter slds-grid"
         >
           <div
-            className="slds-datepicker__filter--month slds-grid slds-grid--align-spread slds-size--2-of-3"
+            className="slds-datepicker__filter_month slds-grid slds-grid_align-spread slds-size_2-of-3"
           >
             <div
               className="slds-align-middle"
             >
               <button
-                className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                 onClick={[Function]}
                 type="button"
               >
@@ -9286,7 +9148,7 @@ exports[`Storyshots Datepicker Default 1`] = `
               className="slds-align-middle"
             >
               <button
-                className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                 onClick={[Function]}
                 type="button"
               >
@@ -9308,7 +9170,7 @@ exports[`Storyshots Datepicker Default 1`] = `
             </div>
           </div>
           <div
-            className="slds-size--1-of-3"
+            className="slds-size_1-of-3"
           >
             <select
               className="slds-select"
@@ -10130,13 +9992,13 @@ exports[`Storyshots Datepicker Extension Rendering 1`] = `
           className="slds-datepicker__filter slds-grid"
         >
           <div
-            className="slds-datepicker__filter--month slds-grid slds-grid--align-spread slds-size--2-of-3"
+            className="slds-datepicker__filter_month slds-grid slds-grid_align-spread slds-size_2-of-3"
           >
             <div
               className="slds-align-middle"
             >
               <button
-                className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                 onClick={[Function]}
                 type="button"
               >
@@ -10165,7 +10027,7 @@ exports[`Storyshots Datepicker Extension Rendering 1`] = `
               className="slds-align-middle"
             >
               <button
-                className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                 onClick={[Function]}
                 type="button"
               >
@@ -10187,7 +10049,7 @@ exports[`Storyshots Datepicker Extension Rendering 1`] = `
             </div>
           </div>
           <div
-            className="slds-size--1-of-3"
+            className="slds-size_1-of-3"
           >
             <select
               className="slds-select"
@@ -10963,7 +10825,7 @@ exports[`Storyshots Datepicker Extension Rendering 1`] = `
           }
         >
           <button
-            className="slds-size--1-of-2 slds-button"
+            className="slds-size_1-of-2 slds-button"
             onClick={[Function]}
             type="button"
           >
@@ -11025,13 +10887,13 @@ exports[`Storyshots Datepicker With max date 1`] = `
           className="slds-datepicker__filter slds-grid"
         >
           <div
-            className="slds-datepicker__filter--month slds-grid slds-grid--align-spread slds-size--2-of-3"
+            className="slds-datepicker__filter_month slds-grid slds-grid_align-spread slds-size_2-of-3"
           >
             <div
               className="slds-align-middle"
             >
               <button
-                className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                 onClick={[Function]}
                 type="button"
               >
@@ -11060,7 +10922,7 @@ exports[`Storyshots Datepicker With max date 1`] = `
               className="slds-align-middle"
             >
               <button
-                className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                 onClick={[Function]}
                 type="button"
               >
@@ -11082,7 +10944,7 @@ exports[`Storyshots Datepicker With max date 1`] = `
             </div>
           </div>
           <div
-            className="slds-size--1-of-3"
+            className="slds-size_1-of-3"
           >
             <select
               className="slds-select"
@@ -11882,13 +11744,13 @@ exports[`Storyshots Datepicker With min date 1`] = `
           className="slds-datepicker__filter slds-grid"
         >
           <div
-            className="slds-datepicker__filter--month slds-grid slds-grid--align-spread slds-size--2-of-3"
+            className="slds-datepicker__filter_month slds-grid slds-grid_align-spread slds-size_2-of-3"
           >
             <div
               className="slds-align-middle"
             >
               <button
-                className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                 onClick={[Function]}
                 type="button"
               >
@@ -11917,7 +11779,7 @@ exports[`Storyshots Datepicker With min date 1`] = `
               className="slds-align-middle"
             >
               <button
-                className="slds-align-middle slds-button slds-button--icon-container slds-button--icon-small"
+                className="slds-align-middle slds-button slds-button_icon-container slds-button_icon-small"
                 onClick={[Function]}
                 type="button"
               >
@@ -11939,7 +11801,7 @@ exports[`Storyshots Datepicker With min date 1`] = `
             </div>
           </div>
           <div
-            className="slds-size--1-of-3"
+            className="slds-size_1-of-3"
           >
             <select
               className="slds-select"
@@ -12739,7 +12601,7 @@ exports[`Storyshots DropdownButton Controlled with knobs 1`] = `
           Dropdown Button
           <svg
             aria-hidden={true}
-            className="slds-button__icon slds-button__icon--right slds-button__icon--small"
+            className="slds-button__icon slds-button__icon_right slds-button__icon_small"
             pointerEvents="none"
           >
             <use
@@ -12796,7 +12658,7 @@ exports[`Storyshots DropdownButton Default 1`] = `
         Dropdown Button
         <svg
           aria-hidden={true}
-          className="slds-button__icon slds-button__icon--right slds-button__icon--small"
+          className="slds-button__icon slds-button__icon_right slds-button__icon_small"
           pointerEvents="none"
         >
           <use
@@ -12830,665 +12692,6 @@ exports[`Storyshots DropdownButton Default 1`] = `
 `;
 
 exports[`Storyshots DropdownButton Hover Popup 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      className="slds-dropdown-trigger slds-button-space-left"
-    >
-      <button
-        aria-haspopup={true}
-        className="slds-button slds-button--neutral"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onMenuSelect={[Function]}
-        type="button"
-      >
-        Dropdown Button
-        <svg
-          aria-hidden={true}
-          className="slds-button__icon slds-button__icon--right slds-button__icon--small"
-          pointerEvents="none"
-        >
-          <use
-            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-          />
-        </svg>
-      </button>
-      <div
-        className="slds-dropdown slds-dropdown--top slds-dropdown--left"
-        onBlur={[Function]}
-        onKeyDown={[Function]}
-        style={
-          Object {
-            "outline": "none",
-            "transition": "none",
-          }
-        }
-        tabIndex={-1}
-      >
-        <ul
-          className="slds-dropdown__list"
-          role="menu"
-        >
-          <li
-            className="slds-dropdown__item"
-          >
-            <a
-              className="slds-truncate react-slds-menuitem"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              role="menuitem"
-              tabIndex={0}
-            >
-              <p
-                className="slds-truncate"
-              >
-                Menu Item One
-              </p>
-            </a>
-          </li>
-          <li
-            className="slds-dropdown__item"
-          >
-            <a
-              aria-disabled={true}
-              className="slds-truncate react-slds-menuitem"
-              role="menuitem"
-            >
-              <p
-                className="slds-truncate"
-              >
-                Menu Item Two
-              </p>
-            </a>
-          </li>
-          <li
-            className="slds-dropdown__item"
-          >
-            <a
-              className="slds-truncate react-slds-menuitem"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              role="menuitem"
-              tabIndex={0}
-            >
-              <p
-                className="slds-truncate"
-              >
-                Menu Item Three
-              </p>
-            </a>
-          </li>
-          <li
-            className="slds-dropdown__item slds-has-divider--top-space"
-          >
-            <a
-              className="slds-truncate react-slds-menuitem"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              role="menuitem"
-              tabIndex={0}
-            >
-              <p
-                className="slds-truncate"
-              >
-                Menu Item Four
-              </p>
-            </a>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        Dropdown is rendered in hover event
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots DropdownButton Icon Bare 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      className="slds-dropdown-trigger slds-button-space-left"
-    >
-      <button
-        aria-haspopup={true}
-        className="slds-button slds-button--icon-bare"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onMenuSelect={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="slds-button__icon"
-          pointerEvents="none"
-        >
-          <use
-            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#settings"
-          />
-        </svg>
-      </button>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        Icon bare dropdown button
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots DropdownButton Icon More 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      className="slds-dropdown-trigger slds-button-space-left"
-    >
-      <button
-        aria-haspopup={true}
-        className="slds-button slds-button--icon-more"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onMenuSelect={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="slds-button__icon"
-          pointerEvents="none"
-        >
-          <use
-            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#settings"
-          />
-        </svg>
-        <svg
-          aria-hidden={true}
-          className="slds-button__icon slds-button__icon--right slds-button__icon--x-small"
-          pointerEvents="none"
-        >
-          <use
-            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-          />
-        </svg>
-      </button>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        Icon and more dropdown button
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots DropdownButton Left icon 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      className="slds-dropdown-trigger slds-button-space-left"
-    >
-      <button
-        aria-haspopup={true}
-        className="slds-button slds-button--icon-border"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onMenuSelect={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="slds-button__icon"
-          pointerEvents="none"
-        >
-          <use
-            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-          />
-        </svg>
-      </button>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        Dropdown button with icon in left side of menu items
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots DropdownButton Left/Right icon 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      className="slds-dropdown-trigger slds-button-space-left"
-    >
-      <button
-        aria-haspopup={true}
-        className="slds-button slds-button--icon-border"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onMenuSelect={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="slds-button__icon"
-          pointerEvents="none"
-        >
-          <use
-            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-          />
-        </svg>
-      </button>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        Dropdown button with icon in left/right side of menu items
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots DropdownButton Neutral 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      className="slds-dropdown-trigger slds-button-space-left"
-    >
-      <button
-        aria-haspopup={true}
-        className="slds-button slds-button--neutral"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onMenuSelect={[Function]}
-        type="button"
-      >
-        Dropdown Button
-        <svg
-          aria-hidden={true}
-          className="slds-button__icon slds-button__icon--right slds-button__icon--small"
-          pointerEvents="none"
-        >
-          <use
-            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-          />
-        </svg>
-      </button>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        Neutral dropdown button
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots DropdownButton Nubbin in top 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      style={
-        Object {
-          "paddingLeft": 100,
-        }
-      }
-    >
-      <div
-        className="slds-dropdown-trigger slds-button-space-left"
-      >
-        <button
-          aria-haspopup={true}
-          className="slds-button slds-button--icon-container"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onMenuSelect={[Function]}
-          type="button"
-        >
-          <svg
-            aria-hidden={true}
-            className="slds-button__icon"
-            pointerEvents="none"
-          >
-            <use
-              xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#settings"
-            />
-          </svg>
-        </button>
-      </div>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        Nubbin in top of the menu dropdown
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots DropdownButton Right aligned menu 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      style={
-        Object {
-          "paddingLeft": 200,
-        }
-      }
-    >
-      <div
-        className="slds-dropdown-trigger slds-button-space-left"
-      >
-        <button
-          aria-haspopup={true}
-          className="slds-button slds-button--icon-border"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onMenuSelect={[Function]}
-          type="button"
-        >
-          <svg
-            aria-hidden={true}
-            className="slds-button__icon"
-            pointerEvents="none"
-          >
-            <use
-              xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-            />
-          </svg>
-        </button>
-      </div>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        Dropdown
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots DropdownButton Right icon 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      className="slds-dropdown-trigger slds-button-space-left"
-    >
-      <button
-        aria-haspopup={true}
-        className="slds-button slds-button--icon-border"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onMenuSelect={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="slds-button__icon"
-          pointerEvents="none"
-        >
-          <use
-            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-          />
-        </svg>
-      </button>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        Dropdown button with icon in right side of menu items
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots DropdownMenu Default 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      className="slds-dropdown slds-dropdown_top slds-dropdown_left react-slds-no-hover-popup"
-      onKeyDown={[Function]}
-      style={
-        Object {
-          "outline": "none",
-        }
-      }
-      tabIndex={-1}
-    >
-      <ul
-        className="slds-dropdown__list"
-        role="menu"
-      />
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        Dropdown button with menu items
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots DropdownMenu Hover Popup 1`] = `
 <div
   className="content-wrapper"
 >
@@ -13634,7 +12837,7 @@ exports[`Storyshots DropdownMenu Hover Popup 1`] = `
 </div>
 `;
 
-exports[`Storyshots DropdownMenu Icon Bare 1`] = `
+exports[`Storyshots DropdownButton Icon Bare 1`] = `
 <div
   className="content-wrapper"
 >
@@ -13689,7 +12892,7 @@ exports[`Storyshots DropdownMenu Icon Bare 1`] = `
 </div>
 `;
 
-exports[`Storyshots DropdownMenu Icon More 1`] = `
+exports[`Storyshots DropdownButton Icon More 1`] = `
 <div
   className="content-wrapper"
 >
@@ -13753,7 +12956,7 @@ exports[`Storyshots DropdownMenu Icon More 1`] = `
 </div>
 `;
 
-exports[`Storyshots DropdownMenu Left icon 1`] = `
+exports[`Storyshots DropdownButton Left icon 1`] = `
 <div
   className="content-wrapper"
 >
@@ -13808,7 +13011,7 @@ exports[`Storyshots DropdownMenu Left icon 1`] = `
 </div>
 `;
 
-exports[`Storyshots DropdownMenu Left/Right icon 1`] = `
+exports[`Storyshots DropdownButton Left/Right icon 1`] = `
 <div
   className="content-wrapper"
 >
@@ -13863,7 +13066,7 @@ exports[`Storyshots DropdownMenu Left/Right icon 1`] = `
 </div>
 `;
 
-exports[`Storyshots DropdownMenu Neutral 1`] = `
+exports[`Storyshots DropdownButton Neutral 1`] = `
 <div
   className="content-wrapper"
 >
@@ -13919,7 +13122,7 @@ exports[`Storyshots DropdownMenu Neutral 1`] = `
 </div>
 `;
 
-exports[`Storyshots DropdownMenu Nubbin in top 1`] = `
+exports[`Storyshots DropdownButton Nubbin in top 1`] = `
 <div
   className="content-wrapper"
 >
@@ -13982,7 +13185,7 @@ exports[`Storyshots DropdownMenu Nubbin in top 1`] = `
 </div>
 `;
 
-exports[`Storyshots DropdownMenu Right aligned menu 1`] = `
+exports[`Storyshots DropdownButton Right aligned menu 1`] = `
 <div
   className="content-wrapper"
 >
@@ -14045,7 +13248,7 @@ exports[`Storyshots DropdownMenu Right aligned menu 1`] = `
 </div>
 `;
 
-exports[`Storyshots DropdownMenu Right icon 1`] = `
+exports[`Storyshots DropdownButton Right icon 1`] = `
 <div
   className="content-wrapper"
 >
@@ -14109,11 +13312,11 @@ exports[`Storyshots Form Compound Form 1`] = `
     style={Object {}}
   >
     <form
-      className="slds-form--compound"
+      className="slds-form_compound"
       onSubmit={[Function]}
     >
       <fieldset
-        className="slds-form--compound"
+        className="slds-form_compound"
       >
         <legend
           className="slds-form-element__label"
@@ -14127,7 +13330,7 @@ exports[`Storyshots Form Compound Form 1`] = `
             className="slds-form-element__row"
           >
             <div
-              className="slds-form-element slds-size--1-of-2"
+              className="slds-form-element slds-size_1-of-2"
             >
               <label
                 className="slds-form-element__label"
@@ -14149,7 +13352,7 @@ exports[`Storyshots Form Compound Form 1`] = `
               </div>
             </div>
             <div
-              className="slds-form-element slds-size--1-of-2"
+              className="slds-form-element slds-size_1-of-2"
             >
               <label
                 className="slds-form-element__label"
@@ -14174,7 +13377,7 @@ exports[`Storyshots Form Compound Form 1`] = `
         </div>
       </fieldset>
       <fieldset
-        className="slds-form--compound"
+        className="slds-form_compound"
       >
         <legend
           className="slds-form-element__label"
@@ -14188,7 +13391,7 @@ exports[`Storyshots Form Compound Form 1`] = `
             className="slds-form-element__row"
           >
             <div
-              className="slds-form-element slds-size--1-of-1"
+              className="slds-form-element slds-size_1-of-1"
             >
               <label
                 className="slds-form-element__label"
@@ -14212,7 +13415,7 @@ exports[`Storyshots Form Compound Form 1`] = `
             className="slds-form-element__row"
           >
             <div
-              className="slds-form-element slds-size--1-of-1"
+              className="slds-form-element slds-size_1-of-1"
             >
               <label
                 className="slds-form-element__label"
@@ -14238,7 +13441,7 @@ exports[`Storyshots Form Compound Form 1`] = `
             className="slds-form-element__row"
           >
             <div
-              className="slds-form-element slds-size--1-of-3"
+              className="slds-form-element slds-size_1-of-3"
             >
               <label
                 className="slds-form-element__label"
@@ -14273,7 +13476,7 @@ exports[`Storyshots Form Compound Form 1`] = `
               </div>
             </div>
             <div
-              className="slds-form-element slds-size--1-of-3"
+              className="slds-form-element slds-size_1-of-3"
             >
               <label
                 className="slds-form-element__label"
@@ -14295,7 +13498,7 @@ exports[`Storyshots Form Compound Form 1`] = `
               </div>
             </div>
             <div
-              className="slds-form-element slds-size--1-of-3"
+              className="slds-form-element slds-size_1-of-3"
             >
               <label
                 className="slds-form-element__label"
@@ -14335,7 +13538,7 @@ exports[`Storyshots Form Compound Form 1`] = `
             className="slds-form-element__row"
           >
             <div
-              className="slds-form-element slds-size--1-of-2"
+              className="slds-form-element slds-size_1-of-2"
             >
               <label
                 className="slds-form-element__label"
@@ -14350,7 +13553,7 @@ exports[`Storyshots Form Compound Form 1`] = `
                   className="slds-picklist slds-dropdown-trigger"
                 >
                   <button
-                    className="slds-picklist__label slds-button slds-button--neutral"
+                    className="slds-picklist__label slds-button slds-button_neutral"
                     id="form-element-$uuid$"
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -14383,7 +13586,7 @@ exports[`Storyshots Form Compound Form 1`] = `
               </div>
             </div>
             <div
-              className="slds-form-element slds-size--1-of-2"
+              className="slds-form-element slds-size_1-of-2"
             >
               <label
                 className="slds-form-element__label"
@@ -14398,7 +13601,7 @@ exports[`Storyshots Form Compound Form 1`] = `
                   className="slds-dropdown-trigger"
                 >
                   <div
-                    className="slds-input-has-icon slds-input-has-icon--right"
+                    className="slds-input-has-icon slds-input-has-icon_right"
                   >
                     <input
                       className="slds-input"
@@ -14409,7 +13612,7 @@ exports[`Storyshots Form Compound Form 1`] = `
                       placeholder="YYYY/MM/DD"
                     />
                     <button
-                      className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                      className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                       onBlur={[Function]}
                       onClick={[Function]}
                       tabIndex={-1}
@@ -14434,7 +13637,7 @@ exports[`Storyshots Form Compound Form 1`] = `
             className="slds-form-element__row"
           >
             <div
-              className="slds-form-element slds-size--3-of-4"
+              className="slds-form-element slds-size_3-of-4"
             >
               <label
                 className="slds-form-element__label"
@@ -14452,7 +13655,7 @@ exports[`Storyshots Form Compound Form 1`] = `
                   data-typeahead={false}
                 >
                   <div
-                    className="slds-grid slds-input-has-icon slds-input-has-icon--right"
+                    className="slds-grid slds-input-has-icon slds-input-has-icon_right"
                   >
                     <input
                       className="slds-input"
@@ -14463,7 +13666,7 @@ exports[`Storyshots Form Compound Form 1`] = `
                       onSubmit={[Function]}
                     />
                     <button
-                      className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                      className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                       onBlur={[Function]}
                       onClick={[Function]}
                       tabIndex={-1}
@@ -14487,7 +13690,7 @@ exports[`Storyshots Form Compound Form 1`] = `
         </div>
       </fieldset>
       <fieldset
-        className="slds-form--compound"
+        className="slds-form_compound"
       >
         <legend
           className="slds-form-element__label"
@@ -14501,7 +13704,7 @@ exports[`Storyshots Form Compound Form 1`] = `
             className="slds-form-element__row"
           >
             <fieldset
-              className="slds-form-element slds-size--1-of-2"
+              className="slds-form-element slds-size_1-of-2"
               name="gender"
               style={
                 Object {
@@ -14510,7 +13713,7 @@ exports[`Storyshots Form Compound Form 1`] = `
               }
             >
               <legend
-                className="slds-form-element__label slds-form-element__label--top"
+                className="slds-form-element__label"
               >
                 Gender
               </legend>
@@ -14527,7 +13730,7 @@ exports[`Storyshots Form Compound Form 1`] = `
                     value={1}
                   />
                   <span
-                    className="slds-radio--faux"
+                    className="slds-radio_faux"
                   />
                   <span
                     className="slds-form-element__label"
@@ -14545,7 +13748,7 @@ exports[`Storyshots Form Compound Form 1`] = `
                     value={2}
                   />
                   <span
-                    className="slds-radio--faux"
+                    className="slds-radio_faux"
                   />
                   <span
                     className="slds-form-element__label"
@@ -14563,7 +13766,7 @@ exports[`Storyshots Form Compound Form 1`] = `
                     value={3}
                   />
                   <span
-                    className="slds-radio--faux"
+                    className="slds-radio_faux"
                   />
                   <span
                     className="slds-form-element__label"
@@ -14574,7 +13777,7 @@ exports[`Storyshots Form Compound Form 1`] = `
               </div>
             </fieldset>
             <fieldset
-              className="slds-form-element slds-size--1-of-2"
+              className="slds-form-element slds-size_1-of-2"
               name="leadSource"
               onChange={[Function]}
               style={
@@ -14584,7 +13787,7 @@ exports[`Storyshots Form Compound Form 1`] = `
               }
             >
               <legend
-                className="slds-form-element__label slds-form-element__label--top"
+                className="slds-form-element__label"
               >
                 Lead Source
               </legend>
@@ -14600,7 +13803,7 @@ exports[`Storyshots Form Compound Form 1`] = `
                     value={1}
                   />
                   <span
-                    className="slds-checkbox--faux"
+                    className="slds-checkbox_faux"
                   />
                   <span
                     className="slds-form-element__label"
@@ -14617,7 +13820,7 @@ exports[`Storyshots Form Compound Form 1`] = `
                     value={2}
                   />
                   <span
-                    className="slds-checkbox--faux"
+                    className="slds-checkbox_faux"
                   />
                   <span
                     className="slds-form-element__label"
@@ -14634,7 +13837,7 @@ exports[`Storyshots Form Compound Form 1`] = `
                     value={3}
                   />
                   <span
-                    className="slds-checkbox--faux"
+                    className="slds-checkbox_faux"
                   />
                   <span
                     className="slds-form-element__label"
@@ -14681,7 +13884,7 @@ exports[`Storyshots Form Horizontal Form 1`] = `
     style={Object {}}
   >
     <form
-      className="slds-form--horizontal"
+      className="slds-form_horizontal"
       onSubmit={[Function]}
     >
       <div
@@ -14727,7 +13930,7 @@ exports[`Storyshots Form Horizontal Form 1`] = `
         onChange={[Function]}
       >
         <legend
-          className="slds-form-element__label slds-form-element__label--top"
+          className="slds-form-element__label"
         >
           Checkbox Group Label
         </legend>
@@ -14741,7 +13944,7 @@ exports[`Storyshots Form Horizontal Form 1`] = `
               type="checkbox"
             />
             <span
-              className="slds-checkbox--faux"
+              className="slds-checkbox_faux"
             />
             <span
               className="slds-form-element__label"
@@ -14756,7 +13959,7 @@ exports[`Storyshots Form Horizontal Form 1`] = `
               type="checkbox"
             />
             <span
-              className="slds-checkbox--faux"
+              className="slds-checkbox_faux"
             />
             <span
               className="slds-form-element__label"
@@ -14771,7 +13974,7 @@ exports[`Storyshots Form Horizontal Form 1`] = `
         name="radiogroup1"
       >
         <legend
-          className="slds-form-element__label slds-form-element__label--top"
+          className="slds-form-element__label"
         >
           Radio Group Label
         </legend>
@@ -14787,7 +13990,7 @@ exports[`Storyshots Form Horizontal Form 1`] = `
               type="radio"
             />
             <span
-              className="slds-radio--faux"
+              className="slds-radio_faux"
             />
             <span
               className="slds-form-element__label"
@@ -14804,7 +14007,7 @@ exports[`Storyshots Form Horizontal Form 1`] = `
               type="radio"
             />
             <span
-              className="slds-radio--faux"
+              className="slds-radio_faux"
             />
             <span
               className="slds-form-element__label"
@@ -14859,7 +14062,7 @@ exports[`Storyshots Form Horizontal Form 1`] = `
             className="slds-picklist slds-dropdown-trigger"
           >
             <button
-              className="slds-picklist__label slds-button slds-button--neutral"
+              className="slds-picklist__label slds-button slds-button_neutral"
               id="form-element-$uuid$"
               onBlur={[Function]}
               onClick={[Function]}
@@ -14907,7 +14110,7 @@ exports[`Storyshots Form Horizontal Form 1`] = `
             className="slds-dropdown-trigger"
           >
             <div
-              className="slds-input-has-icon slds-input-has-icon--right"
+              className="slds-input-has-icon slds-input-has-icon_right"
             >
               <input
                 className="slds-input"
@@ -14917,7 +14120,7 @@ exports[`Storyshots Form Horizontal Form 1`] = `
                 onKeyDown={[Function]}
               />
               <button
-                className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                 onBlur={[Function]}
                 onClick={[Function]}
                 tabIndex={-1}
@@ -14956,7 +14159,7 @@ exports[`Storyshots Form Horizontal Form 1`] = `
             data-typeahead={false}
           >
             <div
-              className="slds-grid slds-input-has-icon slds-input-has-icon--right"
+              className="slds-grid slds-input-has-icon slds-input-has-icon_right"
             >
               <input
                 className="slds-input"
@@ -14967,7 +14170,7 @@ exports[`Storyshots Form Horizontal Form 1`] = `
                 onSubmit={[Function]}
               />
               <button
-                className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                 onBlur={[Function]}
                 onClick={[Function]}
                 tabIndex={-1}
@@ -15021,7 +14224,7 @@ exports[`Storyshots Form Inline Form 1`] = `
     style={Object {}}
   >
     <form
-      className="slds-form--inline"
+      className="slds-form_inline"
       onSubmit={[Function]}
     >
       <div
@@ -15071,7 +14274,7 @@ exports[`Storyshots Form Inline Form 1`] = `
           className="slds-form-element__control"
         >
           <button
-            className="slds-button slds-button--brand"
+            className="slds-button slds-button_brand"
             id="form-element-$uuid$"
             onClick={[Function]}
             type="button"
@@ -15114,7 +14317,7 @@ exports[`Storyshots Form Stacked Form 1`] = `
     style={Object {}}
   >
     <form
-      className="slds-form--stacked"
+      className="slds-form_stacked"
       onSubmit={[Function]}
     >
       <div
@@ -15160,7 +14363,7 @@ exports[`Storyshots Form Stacked Form 1`] = `
         onChange={[Function]}
       >
         <legend
-          className="slds-form-element__label slds-form-element__label--top"
+          className="slds-form-element__label"
         >
           Checkbox Group Label
         </legend>
@@ -15174,7 +14377,7 @@ exports[`Storyshots Form Stacked Form 1`] = `
               type="checkbox"
             />
             <span
-              className="slds-checkbox--faux"
+              className="slds-checkbox_faux"
             />
             <span
               className="slds-form-element__label"
@@ -15189,7 +14392,7 @@ exports[`Storyshots Form Stacked Form 1`] = `
               type="checkbox"
             />
             <span
-              className="slds-checkbox--faux"
+              className="slds-checkbox_faux"
             />
             <span
               className="slds-form-element__label"
@@ -15204,7 +14407,7 @@ exports[`Storyshots Form Stacked Form 1`] = `
         name="radiogroup1"
       >
         <legend
-          className="slds-form-element__label slds-form-element__label--top"
+          className="slds-form-element__label"
         >
           Radio Group Label
         </legend>
@@ -15220,7 +14423,7 @@ exports[`Storyshots Form Stacked Form 1`] = `
               type="radio"
             />
             <span
-              className="slds-radio--faux"
+              className="slds-radio_faux"
             />
             <span
               className="slds-form-element__label"
@@ -15237,7 +14440,7 @@ exports[`Storyshots Form Stacked Form 1`] = `
               type="radio"
             />
             <span
-              className="slds-radio--faux"
+              className="slds-radio_faux"
             />
             <span
               className="slds-form-element__label"
@@ -15292,7 +14495,7 @@ exports[`Storyshots Form Stacked Form 1`] = `
             className="slds-picklist slds-dropdown-trigger"
           >
             <button
-              className="slds-picklist__label slds-button slds-button--neutral"
+              className="slds-picklist__label slds-button slds-button_neutral"
               id="form-element-$uuid$"
               onBlur={[Function]}
               onClick={[Function]}
@@ -15340,7 +14543,7 @@ exports[`Storyshots Form Stacked Form 1`] = `
             className="slds-dropdown-trigger"
           >
             <div
-              className="slds-input-has-icon slds-input-has-icon--right"
+              className="slds-input-has-icon slds-input-has-icon_right"
             >
               <input
                 className="slds-input"
@@ -15350,7 +14553,7 @@ exports[`Storyshots Form Stacked Form 1`] = `
                 onKeyDown={[Function]}
               />
               <button
-                className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                 onBlur={[Function]}
                 onClick={[Function]}
                 tabIndex={-1}
@@ -15389,7 +14592,7 @@ exports[`Storyshots Form Stacked Form 1`] = `
             data-typeahead={false}
           >
             <div
-              className="slds-grid slds-input-has-icon slds-input-has-icon--right"
+              className="slds-grid slds-input-has-icon slds-input-has-icon_right"
             >
               <input
                 className="slds-input"
@@ -15400,7 +14603,7 @@ exports[`Storyshots Form Stacked Form 1`] = `
                 onSubmit={[Function]}
               />
               <button
-                className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                 onBlur={[Function]}
                 onClick={[Function]}
                 tabIndex={-1}
@@ -15445,98 +14648,6 @@ exports[`Storyshots Form Stacked Form 1`] = `
 </div>
 `;
 
-exports[`Storyshots Grid Col padded 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      className="slds-grid slds-grid_vertical"
-    >
-      <div
-        className="slds-grid slds-wrap"
-      >
-        <div
-          className="slds-col_padded"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            A
-          </div>
-        </div>
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            B
-          </div>
-        </div>
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            C
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        rows with 
-        <code>
-          nowrap
-        </code>
-         prop
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Storyshots Grid Equally Weighted 1`] = `
 <div
   className="content-wrapper"
@@ -15546,7 +14657,7 @@ exports[`Storyshots Grid Equally Weighted 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-grid slds-grid--vertical"
+      className="slds-grid slds-grid_vertical"
     >
       <div
         className="slds-grid slds-wrap"
@@ -15625,654 +14736,6 @@ exports[`Storyshots Grid Equally Weighted 1`] = `
 </div>
 `;
 
-exports[`Storyshots Grid Frame 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      className="slds-grid slds-grid_vertical slds-grid_frame"
-    >
-      <div
-        className="slds-grid slds-wrap"
-      >
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            A
-          </div>
-        </div>
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            B
-          </div>
-        </div>
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            C
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        grid with frame
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Grid Responsive Col Order 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      className="slds-grid slds-grid_vertical"
-    >
-      <div
-        className="slds-grid slds-wrap"
-      >
-        <div
-          className="slds-col slds-order_3 slds-small-order_1 slds-medium-order_2 slds-large-order_3"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            A
-          </div>
-        </div>
-        <div
-          className="slds-col slds-order_2 slds-small-order_2 slds-medium-order_1 slds-large-order_1"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            B
-          </div>
-        </div>
-        <div
-          className="slds-col slds-order_1 slds-small-order_3 slds-medium-order_3 slds-large-order_2"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            C
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        cols with 
-        <code>
-          order
-        </code>
-         prop
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Grid Responsive Col Size 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      className="slds-grid slds-grid_vertical"
-    >
-      <div
-        className="slds-grid slds-wrap"
-      >
-        <div
-          className="slds-col slds-small-size_2-of-4 slds-medium-size_1-of-4 slds-large-size_1-of-4"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            A
-          </div>
-        </div>
-        <div
-          className="slds-col slds-small-size_1-of-4 slds-medium-size_2-of-4 slds-large-size_1-of-4"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            B
-          </div>
-        </div>
-        <div
-          className="slds-col slds-small-size_1-of-4 slds-medium-size_1-of-4 slds-large-size_2-of-4"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            C
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        responsive layout
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Grid Row Align 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      className="slds-grid slds-grid_vertical"
-    >
-      <div
-        className="slds-grid slds-grid_align-center slds-wrap"
-      >
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            A
-          </div>
-        </div>
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            B
-          </div>
-        </div>
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            C
-          </div>
-        </div>
-      </div>
-      <div
-        className="slds-grid slds-grid_align-space slds-wrap"
-      >
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            A
-          </div>
-        </div>
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            B
-          </div>
-        </div>
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            C
-          </div>
-        </div>
-      </div>
-      <div
-        className="slds-grid slds-grid_align-spread slds-wrap"
-      >
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            A
-          </div>
-        </div>
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            B
-          </div>
-        </div>
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            C
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        rows with 
-        <code>
-          align
-        </code>
-         prop
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Grid Row nowrap 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      className="slds-grid slds-grid_vertical"
-    >
-      <div
-        className="slds-grid slds-wrap slds-nowrap_small"
-      >
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            A
-          </div>
-        </div>
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            B
-          </div>
-        </div>
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            C
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        rows with 
-        <code>
-          nowrap
-        </code>
-         prop
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Grid Row pullPadded 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      className="slds-grid slds-grid_vertical"
-    >
-      <div
-        className="slds-grid slds-wrap slds-grid_pull-padded"
-      >
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            A
-          </div>
-        </div>
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            B
-          </div>
-        </div>
-        <div
-          className="slds-col"
-        >
-          <div
-            style={
-              Object {
-                "backgroundColor": "#33f",
-                "border": "1px solid #aaf",
-                "color": "#fff",
-                "padding": "12px",
-              }
-            }
-          >
-            C
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        rows with 
-        <code>
-          nowrap
-        </code>
-         prop
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Storyshots Grid Weighted 1`] = `
 <div
   className="content-wrapper"
@@ -16282,13 +14745,13 @@ exports[`Storyshots Grid Weighted 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-grid slds-grid--vertical"
+      className="slds-grid slds-grid_vertical"
     >
       <div
         className="slds-grid slds-wrap"
       >
         <div
-          className="slds-col slds-size--1-of-4"
+          className="slds-col slds-size_1-of-4"
         >
           <div
             style={
@@ -16304,7 +14767,7 @@ exports[`Storyshots Grid Weighted 1`] = `
           </div>
         </div>
         <div
-          className="slds-col slds-size--2-of-4"
+          className="slds-col slds-size_2-of-4"
         >
           <div
             style={
@@ -16320,7 +14783,7 @@ exports[`Storyshots Grid Weighted 1`] = `
           </div>
         </div>
         <div
-          className="slds-col slds-size--1-of-4"
+          className="slds-col slds-size_1-of-4"
         >
           <div
             style={
@@ -16370,13 +14833,13 @@ exports[`Storyshots Grid Weighted, no-flex 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-grid slds-grid--vertical"
+      className="slds-grid slds-grid_vertical"
     >
       <div
         className="slds-grid slds-wrap"
       >
         <div
-          className="slds-col slds-no-flex slds-size--1-of-12"
+          className="slds-col slds-no-flex slds-size_1-of-12"
         >
           <div
             style={
@@ -16392,7 +14855,7 @@ exports[`Storyshots Grid Weighted, no-flex 1`] = `
           </div>
         </div>
         <div
-          className="slds-col slds-no-flex slds-size--1-of-12"
+          className="slds-col slds-no-flex slds-size_1-of-12"
         >
           <div
             style={
@@ -16408,7 +14871,7 @@ exports[`Storyshots Grid Weighted, no-flex 1`] = `
           </div>
         </div>
         <div
-          className="slds-col slds-no-flex slds-size--2-of-12"
+          className="slds-col slds-no-flex slds-size_2-of-12"
         >
           <div
             style={
@@ -16424,7 +14887,7 @@ exports[`Storyshots Grid Weighted, no-flex 1`] = `
           </div>
         </div>
         <div
-          className="slds-col slds-no-flex slds-size--3-of-12"
+          className="slds-col slds-no-flex slds-size_3-of-12"
         >
           <div
             style={
@@ -16440,7 +14903,7 @@ exports[`Storyshots Grid Weighted, no-flex 1`] = `
           </div>
         </div>
         <div
-          className="slds-col slds-no-flex slds-size--3-of-12"
+          className="slds-col slds-no-flex slds-size_3-of-12"
         >
           <div
             style={
@@ -16493,7 +14956,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
       className="slds-clearfix"
     >
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -16506,11 +14969,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-add-contact"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-add-contact"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -16524,7 +14987,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -16537,11 +15000,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-announcement"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-announcement"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -16555,7 +15018,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -16568,11 +15031,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-apex"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-apex"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -16586,7 +15049,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -16599,11 +15062,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-approval"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-approval"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -16617,7 +15080,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -16630,11 +15093,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-back"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-back"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -16648,7 +15111,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -16661,11 +15124,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-call"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-call"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -16679,7 +15142,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -16692,11 +15155,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-canvas"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-canvas"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -16710,7 +15173,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -16723,11 +15186,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-change-owner"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-change-owner"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -16741,7 +15204,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -16754,11 +15217,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-change-record-type"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-change-record-type"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -16772,7 +15235,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -16785,11 +15248,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-check"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-check"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -16803,7 +15266,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -16816,11 +15279,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-clone"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-clone"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -16834,7 +15297,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -16847,11 +15310,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-close"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-close"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -16865,7 +15328,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -16878,11 +15341,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-defer"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-defer"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -16896,7 +15359,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -16909,11 +15372,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-delete"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-delete"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -16927,7 +15390,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -16940,11 +15403,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-description"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-description"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -16958,7 +15421,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -16971,11 +15434,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-dial-in"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-dial-in"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -16989,7 +15452,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17002,11 +15465,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-download"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-download"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17020,7 +15483,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17033,11 +15496,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-edit"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-edit"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17051,7 +15514,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17064,11 +15527,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-edit-groups"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-edit-groups"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17082,7 +15545,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17095,11 +15558,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-edit-relationship"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-edit-relationship"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17113,7 +15576,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17126,11 +15589,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-email"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-email"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17144,7 +15607,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17157,11 +15620,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-fallback"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-fallback"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17175,7 +15638,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17188,11 +15651,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-filter"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-filter"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17206,7 +15669,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17219,11 +15682,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-flow"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-flow"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17237,7 +15700,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17250,11 +15713,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-follow"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-follow"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17268,7 +15731,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17281,11 +15744,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-following"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-following"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17299,7 +15762,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17312,11 +15775,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-freeze-user"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-freeze-user"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17330,7 +15793,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17343,11 +15806,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-goal"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-goal"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17361,7 +15824,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17374,11 +15837,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-google-news"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-google-news"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17392,7 +15855,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17405,11 +15868,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-info"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-info"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17423,7 +15886,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17436,11 +15899,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-join-group"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-join-group"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17454,7 +15917,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17467,11 +15930,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-lead-convert"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-lead-convert"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17485,7 +15948,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17498,11 +15961,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-leave-group"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-leave-group"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17516,7 +15979,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17529,11 +15992,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-log-a-call"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-log-a-call"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17547,7 +16010,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17560,11 +16023,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-log-event"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-log-event"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17578,7 +16041,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17591,11 +16054,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-manage-perm-sets"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-manage-perm-sets"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17609,7 +16072,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17622,11 +16085,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-map"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-map"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17640,7 +16103,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17653,11 +16116,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-more"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-more"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17671,7 +16134,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17684,11 +16147,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-new"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-new"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17702,7 +16165,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17715,11 +16178,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-new-account"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-new-account"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17733,7 +16196,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17746,11 +16209,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-new-campaign"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-new-campaign"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17764,7 +16227,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17777,11 +16240,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-new-case"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-new-case"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17795,7 +16258,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17808,11 +16271,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-new-child-case"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-new-child-case"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17826,7 +16289,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17839,11 +16302,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-new-contact"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-new-contact"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17857,7 +16320,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17870,11 +16333,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-new-event"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-new-event"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17888,7 +16351,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17901,11 +16364,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-new-group"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-new-group"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17919,7 +16382,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17932,11 +16395,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-new-lead"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-new-lead"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17950,7 +16413,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17963,11 +16426,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-new-note"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-new-note"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -17981,7 +16444,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -17994,11 +16457,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-new-notebook"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-new-notebook"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18012,7 +16475,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18025,11 +16488,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-new-opportunity"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-new-opportunity"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18043,7 +16506,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18056,11 +16519,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-new-person-account"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-new-person-account"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18074,7 +16537,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18087,11 +16550,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-new-task"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-new-task"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18105,7 +16568,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18118,11 +16581,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-password-unlock"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-password-unlock"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18136,7 +16599,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18149,11 +16612,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-preview"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-preview"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18167,7 +16630,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18180,11 +16643,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-priority"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-priority"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18198,7 +16661,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18211,11 +16674,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-question-post-action"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-question-post-action"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18229,7 +16692,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18242,11 +16705,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-quote"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-quote"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18260,7 +16723,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18273,11 +16736,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-record"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-record"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18291,7 +16754,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18304,11 +16767,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-refresh"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-refresh"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18322,7 +16785,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18335,11 +16798,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-reject"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-reject"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18353,7 +16816,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18366,11 +16829,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-remove"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-remove"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18384,7 +16847,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18397,11 +16860,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-reset-password"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-reset-password"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18415,7 +16878,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18428,11 +16891,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-share"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-share"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18446,7 +16909,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18459,11 +16922,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-share-file"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-share-file"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18477,7 +16940,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18490,11 +16953,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-share-link"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-share-link"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18508,7 +16971,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18521,11 +16984,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-share-poll"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-share-poll"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18539,7 +17002,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18552,11 +17015,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-share-post"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-share-post"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18570,7 +17033,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18583,11 +17046,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-share-thanks"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-share-thanks"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18601,7 +17064,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18614,11 +17077,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-sort"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-sort"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18632,7 +17095,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18645,11 +17108,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-submit-for-approval"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-submit-for-approval"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18663,7 +17126,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18676,11 +17139,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-update"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-update"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18694,7 +17157,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18707,11 +17170,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-update-status"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-update-status"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18725,7 +17188,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18738,11 +17201,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-upload"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-upload"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18756,7 +17219,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18769,11 +17232,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-user"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-user"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18787,7 +17250,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18800,11 +17263,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-user-activation"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-user-activation"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18818,7 +17281,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18831,11 +17294,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-action-web-link"
+            className="slds-icon_container slds-icon_container_circle slds-icon-action-web-link"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18849,7 +17312,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18862,11 +17325,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-7"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-7"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18880,7 +17343,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18893,11 +17356,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-8"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-8"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18911,7 +17374,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18924,11 +17387,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-9"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-9"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18942,7 +17405,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18955,11 +17418,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-10"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-10"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -18973,7 +17436,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -18986,11 +17449,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-11"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-11"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19004,7 +17467,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19017,11 +17480,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-12"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-12"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19035,7 +17498,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19048,11 +17511,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-13"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-13"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19066,7 +17529,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19079,11 +17542,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-14"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-14"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19097,7 +17560,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19110,11 +17573,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-15"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-15"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19128,7 +17591,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19141,11 +17604,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-16"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-16"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19159,7 +17622,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19172,11 +17635,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-17"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-17"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19190,7 +17653,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19203,11 +17666,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-18"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-18"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19221,7 +17684,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19234,11 +17697,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-19"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-19"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19252,7 +17715,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19265,11 +17728,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-20"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-20"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19283,7 +17746,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19296,11 +17759,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-21"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-21"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19314,7 +17777,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19327,11 +17790,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-22"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-22"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19345,7 +17808,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19358,11 +17821,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-23"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-23"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19376,7 +17839,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19389,11 +17852,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-24"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-24"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19407,7 +17870,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19420,11 +17883,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-25"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-25"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19438,7 +17901,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19451,11 +17914,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-26"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-26"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19469,7 +17932,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19482,11 +17945,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-27"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-27"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19500,7 +17963,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19513,11 +17976,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-28"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-28"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19531,7 +17994,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19544,11 +18007,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-29"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-29"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19562,7 +18025,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19575,11 +18038,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-30"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-30"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19593,7 +18056,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19606,11 +18069,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-31"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-31"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19624,7 +18087,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19637,11 +18100,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-32"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-32"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19655,7 +18118,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19668,11 +18131,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-33"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-33"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19686,7 +18149,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19699,11 +18162,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-34"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-34"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19717,7 +18180,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19730,11 +18193,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-35"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-35"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19748,7 +18211,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19761,11 +18224,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-36"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-36"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19779,7 +18242,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19792,11 +18255,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-37"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-37"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19810,7 +18273,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19823,11 +18286,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-38"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-38"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19841,7 +18304,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19854,11 +18317,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-39"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-39"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19872,7 +18335,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19885,11 +18348,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-40"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-40"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19903,7 +18366,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19916,11 +18379,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-41"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-41"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19934,7 +18397,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19947,11 +18410,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-42"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-42"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19965,7 +18428,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -19978,11 +18441,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-43"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-43"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -19996,7 +18459,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20009,11 +18472,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-44"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-44"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20027,7 +18490,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20040,11 +18503,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-45"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-45"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20058,7 +18521,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20071,11 +18534,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-46"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-46"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20089,7 +18552,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20102,11 +18565,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-47"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-47"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20120,7 +18583,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20133,11 +18596,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-48"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-48"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20151,7 +18614,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20164,11 +18627,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-49"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-49"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20182,7 +18645,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20195,11 +18658,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-50"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-50"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20213,7 +18676,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20226,11 +18689,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-51"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-51"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20244,7 +18707,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20257,11 +18720,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-52"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-52"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20275,7 +18738,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20288,11 +18751,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-53"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-53"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20306,7 +18769,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20319,11 +18782,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-54"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-54"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20337,7 +18800,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20350,11 +18813,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-55"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-55"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20368,7 +18831,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20381,11 +18844,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-56"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-56"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20399,7 +18862,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20412,11 +18875,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-57"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-57"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20430,7 +18893,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20443,11 +18906,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-58"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-58"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20461,7 +18924,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20474,11 +18937,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-59"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-59"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20492,7 +18955,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20505,11 +18968,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-60"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-60"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20523,7 +18986,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20536,11 +18999,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-61"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-61"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20554,7 +19017,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20567,11 +19030,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-62"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-62"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20585,7 +19048,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20598,11 +19061,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-63"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-63"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20616,7 +19079,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20629,11 +19092,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-64"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-64"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20647,7 +19110,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20660,11 +19123,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-65"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-65"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20678,7 +19141,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20691,11 +19154,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-66"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-66"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20709,7 +19172,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20722,11 +19185,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-67"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-67"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20740,7 +19203,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20753,11 +19216,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-68"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-68"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20771,7 +19234,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20784,11 +19247,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-69"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-69"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20802,7 +19265,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20815,11 +19278,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-70"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-70"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20833,7 +19296,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20846,11 +19309,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-71"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-71"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20864,7 +19327,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20877,11 +19340,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-72"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-72"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20895,7 +19358,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20908,11 +19371,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-73"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-73"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20926,7 +19389,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20939,11 +19402,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-74"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-74"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20957,7 +19420,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -20970,11 +19433,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-75"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-75"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -20988,7 +19451,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21001,11 +19464,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-76"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-76"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21019,7 +19482,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21032,11 +19495,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-77"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-77"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21050,7 +19513,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21063,11 +19526,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-78"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-78"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21081,7 +19544,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21094,11 +19557,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-79"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-79"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21112,7 +19575,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21125,11 +19588,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-80"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-80"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21143,7 +19606,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21156,11 +19619,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-81"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-81"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21174,7 +19637,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21187,11 +19650,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-82"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-82"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21205,7 +19668,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21218,11 +19681,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-83"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-83"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21236,7 +19699,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21249,11 +19712,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-84"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-84"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21267,7 +19730,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21280,11 +19743,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-85"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-85"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21298,7 +19761,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21311,11 +19774,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-86"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-86"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21329,7 +19792,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21342,11 +19805,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-87"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-87"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21360,7 +19823,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21373,11 +19836,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-88"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-88"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21391,7 +19854,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21404,11 +19867,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-89"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-89"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21422,7 +19885,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21435,11 +19898,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-90"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-90"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21453,7 +19916,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21466,11 +19929,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-91"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-91"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21484,7 +19947,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21497,11 +19960,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-92"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-92"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21515,7 +19978,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21528,11 +19991,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-93"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-93"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21546,7 +20009,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21559,11 +20022,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-94"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-94"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21577,7 +20040,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21590,11 +20053,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-95"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-95"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21608,7 +20071,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21621,11 +20084,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-96"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-96"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21639,7 +20102,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21652,11 +20115,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-97"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-97"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21670,7 +20133,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21683,11 +20146,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-98"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-98"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21701,7 +20164,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21714,11 +20177,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-99"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-99"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21732,7 +20195,7 @@ exports[`Storyshots Icon Action Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21745,11 +20208,11 @@ exports[`Storyshots Icon Action Icons 1`] = `
       >
         <figure>
           <span
-            className="slds-icon__container slds-icon__container--circle slds-icon-custom-100"
+            className="slds-icon_container slds-icon_container_circle slds-icon-custom-100"
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small"
+              className="slds-icon slds-icon_small"
               onClick={[Function]}
             >
               <use
@@ -21787,110 +20250,6 @@ exports[`Storyshots Icon Action Icons 1`] = `
 </div>
 `;
 
-exports[`Storyshots Icon Align 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      style={
-        Object {
-          "outline": "1px dashed",
-          "width": "100px",
-        }
-      }
-    >
-      <svg
-        aria-hidden={true}
-        className="slds-icon slds-icon-standard-case slds-m-right_x-small"
-        onClick={[Function]}
-      >
-        <use
-          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#case"
-        />
-      </svg>
-      <svg
-        aria-hidden={true}
-        className="slds-icon slds-icon-standard-case slds-m-left_x-small"
-        onClick={[Function]}
-      >
-        <use
-          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#case"
-        />
-      </svg>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        Icon with different size (x-small, small, medium, large)
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Icon Container 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <span
-      className="slds-icon_container slds-icon_container_circle slds-icon-standard-case"
-    >
-      <svg
-        aria-hidden={true}
-        className="slds-icon"
-        onClick={[Function]}
-      >
-        <use
-          xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#case"
-        />
-      </svg>
-    </span>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        Icon with different size (x-small, small, medium, large)
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Storyshots Icon Controlled with knobs 1`] = `
 <div
   className="content-wrapper"
@@ -21901,7 +20260,7 @@ exports[`Storyshots Icon Controlled with knobs 1`] = `
   >
     <svg
       aria-hidden={true}
-      className="slds-icon slds-icon--medium slds-icon-standard-account"
+      className="slds-icon slds-icon_medium slds-icon-standard-account"
     >
       <use
         xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account"
@@ -21943,7 +20302,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
       className="slds-clearfix"
     >
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21970,7 +20329,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -21997,7 +20356,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22024,7 +20383,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22051,7 +20410,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22078,7 +20437,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22105,7 +20464,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22132,7 +20491,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22159,7 +20518,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22186,7 +20545,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22213,7 +20572,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22240,7 +20599,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22267,7 +20626,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22294,7 +20653,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22321,7 +20680,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22348,7 +20707,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22375,7 +20734,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22402,7 +20761,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22429,7 +20788,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22456,7 +20815,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22483,7 +20842,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22510,7 +20869,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22537,7 +20896,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22564,7 +20923,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22591,7 +20950,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22618,7 +20977,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22645,7 +21004,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22672,7 +21031,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22699,7 +21058,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22726,7 +21085,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22753,7 +21112,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22780,7 +21139,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22807,7 +21166,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22834,7 +21193,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22861,7 +21220,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22888,7 +21247,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22915,7 +21274,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22942,7 +21301,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22969,7 +21328,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -22996,7 +21355,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23023,7 +21382,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23050,7 +21409,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23077,7 +21436,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23104,7 +21463,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23131,7 +21490,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23158,7 +21517,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23185,7 +21544,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23212,7 +21571,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23239,7 +21598,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23266,7 +21625,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23293,7 +21652,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23320,7 +21679,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23347,7 +21706,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23374,7 +21733,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23401,7 +21760,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23428,7 +21787,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23455,7 +21814,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23482,7 +21841,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23509,7 +21868,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23536,7 +21895,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23563,7 +21922,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23590,7 +21949,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23617,7 +21976,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23644,7 +22003,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23671,7 +22030,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23698,7 +22057,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23725,7 +22084,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23752,7 +22111,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23779,7 +22138,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23806,7 +22165,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23833,7 +22192,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23860,7 +22219,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23887,7 +22246,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23914,7 +22273,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23941,7 +22300,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23968,7 +22327,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -23995,7 +22354,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24022,7 +22381,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24049,7 +22408,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24076,7 +22435,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24103,7 +22462,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24130,7 +22489,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24157,7 +22516,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24184,7 +22543,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24211,7 +22570,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24238,7 +22597,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24265,7 +22624,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24292,7 +22651,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24319,7 +22678,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24346,7 +22705,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24373,7 +22732,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24400,7 +22759,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24427,7 +22786,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24454,7 +22813,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24481,7 +22840,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24508,7 +22867,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24535,7 +22894,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24562,7 +22921,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24589,7 +22948,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24616,7 +22975,7 @@ exports[`Storyshots Icon Custom Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24679,7 +23038,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
       className="slds-clearfix"
     >
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24706,7 +23065,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24733,7 +23092,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24760,7 +23119,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24787,7 +23146,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24814,7 +23173,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24841,7 +23200,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24868,7 +23227,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24895,7 +23254,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24922,7 +23281,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24949,7 +23308,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -24976,7 +23335,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25003,7 +23362,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25030,7 +23389,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25057,7 +23416,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25084,7 +23443,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25111,7 +23470,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25138,7 +23497,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25165,7 +23524,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25192,7 +23551,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25219,7 +23578,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25246,7 +23605,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25273,7 +23632,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25300,7 +23659,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25327,7 +23686,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25354,7 +23713,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25381,7 +23740,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25408,7 +23767,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25435,7 +23794,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25462,7 +23821,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25489,7 +23848,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25516,7 +23875,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25543,7 +23902,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25570,7 +23929,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25597,7 +23956,7 @@ exports[`Storyshots Icon Doctype Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25659,7 +24018,7 @@ exports[`Storyshots Icon Sizes 1`] = `
     <div>
       <svg
         aria-hidden={true}
-        className="slds-icon slds-icon--x-small slds-icon-standard-case"
+        className="slds-icon slds-icon_x-small slds-icon-standard-case"
         onClick={[Function]}
       >
         <use
@@ -25667,11 +24026,11 @@ exports[`Storyshots Icon Sizes 1`] = `
         />
       </svg>
       <span
-        className="slds-p-right--small"
+        className="slds-p-right_small"
       />
       <svg
         aria-hidden={true}
-        className="slds-icon slds-icon--small slds-icon-standard-case"
+        className="slds-icon slds-icon_small slds-icon-standard-case"
         onClick={[Function]}
       >
         <use
@@ -25679,11 +24038,11 @@ exports[`Storyshots Icon Sizes 1`] = `
         />
       </svg>
       <span
-        className="slds-p-right--small"
+        className="slds-p-right_small"
       />
       <svg
         aria-hidden={true}
-        className="slds-icon slds-icon--medium slds-icon-standard-case"
+        className="slds-icon slds-icon_medium slds-icon-standard-case"
         onClick={[Function]}
       >
         <use
@@ -25691,11 +24050,11 @@ exports[`Storyshots Icon Sizes 1`] = `
         />
       </svg>
       <span
-        className="slds-p-right--small"
+        className="slds-p-right_small"
       />
       <svg
         aria-hidden={true}
-        className="slds-icon slds-icon--large slds-icon-standard-case"
+        className="slds-icon slds-icon_large slds-icon-standard-case"
         onClick={[Function]}
       >
         <use
@@ -25739,7 +24098,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
       className="slds-clearfix"
     >
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25766,7 +24125,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25793,7 +24152,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25820,7 +24179,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25847,7 +24206,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25874,7 +24233,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25901,7 +24260,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25928,7 +24287,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25955,7 +24314,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -25982,7 +24341,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26009,7 +24368,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26036,7 +24395,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26063,7 +24422,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26090,7 +24449,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26117,7 +24476,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26144,7 +24503,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26171,7 +24530,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26198,7 +24557,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26225,7 +24584,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26252,7 +24611,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26279,7 +24638,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26306,7 +24665,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26333,7 +24692,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26360,7 +24719,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26387,7 +24746,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26414,7 +24773,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26441,7 +24800,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26468,7 +24827,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26495,7 +24854,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26522,7 +24881,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26549,7 +24908,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26576,7 +24935,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26603,7 +24962,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26630,7 +24989,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26657,7 +25016,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26684,7 +25043,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26711,7 +25070,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26738,7 +25097,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26765,7 +25124,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26792,7 +25151,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26819,7 +25178,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26846,7 +25205,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26873,7 +25232,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26900,7 +25259,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26927,7 +25286,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26954,7 +25313,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -26981,7 +25340,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27008,7 +25367,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27035,7 +25394,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27062,7 +25421,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27089,7 +25448,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27116,7 +25475,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27143,7 +25502,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27170,7 +25529,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27197,7 +25556,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27224,7 +25583,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27251,7 +25610,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27278,7 +25637,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27305,7 +25664,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27332,7 +25691,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27359,7 +25718,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27386,7 +25745,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27413,7 +25772,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27440,7 +25799,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27467,7 +25826,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27494,7 +25853,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27521,7 +25880,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27548,7 +25907,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27575,7 +25934,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27602,7 +25961,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27629,7 +25988,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27656,7 +26015,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27683,7 +26042,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27710,7 +26069,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27737,7 +26096,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27764,7 +26123,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27791,7 +26150,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27818,7 +26177,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27845,7 +26204,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27872,7 +26231,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27899,7 +26258,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27926,7 +26285,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27953,7 +26312,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -27980,7 +26339,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28007,7 +26366,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28034,7 +26393,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28061,7 +26420,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28088,7 +26447,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28115,7 +26474,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28142,7 +26501,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28169,7 +26528,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28196,7 +26555,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28223,7 +26582,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28250,7 +26609,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28277,7 +26636,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28304,7 +26663,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28331,7 +26690,7 @@ exports[`Storyshots Icon Standard Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28394,7 +26753,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
       className="slds-clearfix"
     >
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28421,7 +26780,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28448,7 +26807,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28475,7 +26834,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28502,7 +26861,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28529,7 +26888,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28556,7 +26915,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28583,7 +26942,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28610,7 +26969,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28637,7 +26996,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28664,7 +27023,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28691,7 +27050,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28718,7 +27077,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28745,7 +27104,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28772,7 +27131,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28799,7 +27158,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28826,7 +27185,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28853,7 +27212,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28880,7 +27239,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28907,7 +27266,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28934,7 +27293,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28961,7 +27320,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -28988,7 +27347,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29015,7 +27374,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29042,7 +27401,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29069,7 +27428,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29096,7 +27455,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29123,7 +27482,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29150,7 +27509,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29177,7 +27536,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29204,7 +27563,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29231,7 +27590,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29258,7 +27617,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29285,7 +27644,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29312,7 +27671,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29339,7 +27698,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29366,7 +27725,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29393,7 +27752,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29420,7 +27779,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29447,7 +27806,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29474,7 +27833,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29501,7 +27860,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29528,7 +27887,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29555,7 +27914,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29582,7 +27941,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29609,7 +27968,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29636,7 +27995,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29663,7 +28022,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29690,7 +28049,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29717,7 +28076,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29744,7 +28103,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29771,7 +28130,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29798,7 +28157,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29825,7 +28184,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29852,7 +28211,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29879,7 +28238,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29906,7 +28265,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29933,7 +28292,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29960,7 +28319,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -29987,7 +28346,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30014,7 +28373,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30041,7 +28400,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30068,7 +28427,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30095,7 +28454,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30122,7 +28481,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30149,7 +28508,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30176,7 +28535,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30203,7 +28562,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30230,7 +28589,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30257,7 +28616,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30284,7 +28643,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30311,7 +28670,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30338,7 +28697,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30365,7 +28724,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30392,7 +28751,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30419,7 +28778,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30446,7 +28805,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30473,7 +28832,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30500,7 +28859,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30527,7 +28886,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30554,7 +28913,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30581,7 +28940,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30608,7 +28967,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30635,7 +28994,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30662,7 +29021,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30689,7 +29048,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30716,7 +29075,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30743,7 +29102,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30770,7 +29129,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30797,7 +29156,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30824,7 +29183,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30851,7 +29210,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30878,7 +29237,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30905,7 +29264,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30932,7 +29291,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30959,7 +29318,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -30986,7 +29345,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31013,7 +29372,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31040,7 +29399,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31067,7 +29426,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31094,7 +29453,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31121,7 +29480,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31148,7 +29507,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31175,7 +29534,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31202,7 +29561,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31229,7 +29588,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31256,7 +29615,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31283,7 +29642,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31310,7 +29669,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31337,7 +29696,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31364,7 +29723,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31391,7 +29750,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31418,7 +29777,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31445,7 +29804,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31472,7 +29831,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31499,7 +29858,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31526,7 +29885,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31553,7 +29912,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31580,7 +29939,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31607,7 +29966,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31634,7 +29993,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31661,7 +30020,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31688,7 +30047,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31715,7 +30074,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31742,7 +30101,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31769,7 +30128,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31796,7 +30155,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31823,7 +30182,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31850,7 +30209,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31877,7 +30236,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31904,7 +30263,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31931,7 +30290,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31958,7 +30317,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -31985,7 +30344,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32012,7 +30371,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32039,7 +30398,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32066,7 +30425,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32093,7 +30452,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32120,7 +30479,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32147,7 +30506,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32174,7 +30533,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32201,7 +30560,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32228,7 +30587,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32255,7 +30614,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32282,7 +30641,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32309,7 +30668,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32336,7 +30695,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32363,7 +30722,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32390,7 +30749,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32417,7 +30776,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32444,7 +30803,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32471,7 +30830,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32498,7 +30857,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32525,7 +30884,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32552,7 +30911,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32579,7 +30938,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32606,7 +30965,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32633,7 +30992,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32660,7 +31019,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32687,7 +31046,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32714,7 +31073,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32741,7 +31100,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32768,7 +31127,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32795,7 +31154,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32822,7 +31181,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32849,7 +31208,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32876,7 +31235,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32903,7 +31262,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32930,7 +31289,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32957,7 +31316,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -32984,7 +31343,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33011,7 +31370,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33038,7 +31397,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33065,7 +31424,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33092,7 +31451,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33119,7 +31478,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33146,7 +31505,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33173,7 +31532,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33200,7 +31559,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33227,7 +31586,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33254,7 +31613,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33281,7 +31640,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33308,7 +31667,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33335,7 +31694,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33362,7 +31721,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33389,7 +31748,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33416,7 +31775,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33443,7 +31802,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33470,7 +31829,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33497,7 +31856,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33524,7 +31883,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33551,7 +31910,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33578,7 +31937,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33605,7 +31964,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33632,7 +31991,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33659,7 +32018,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33686,7 +32045,7 @@ exports[`Storyshots Icon Utility Icons 1`] = `
         </figure>
       </li>
       <li
-        className="slds-p-around--small"
+        className="slds-p-around_small"
         style={
           Object {
             "float": "left",
@@ -33758,7 +32117,7 @@ exports[`Storyshots Input Bare 1`] = `
         className="slds-form-element__control"
       >
         <input
-          className="slds-input--bare"
+          className="slds-input_bare"
           id="input-$uuid$"
           onChange={[Function]}
           onKeyDown={[Function]}
@@ -34042,11 +32401,11 @@ exports[`Storyshots Input Error with icon 1`] = `
         className="slds-form-element__control"
       >
         <div
-          className="slds-form-element__control slds-input-has-icon slds-input-has-icon--left"
+          className="slds-form-element__control slds-input-has-icon slds-input-has-icon_left"
         >
           <svg
             aria-hidden={true}
-            className="slds-icon slds-icon-text-default slds-input__icon slds-input__icon--left slds-icon-text-default"
+            className="slds-icon slds-icon-text-default slds-input__icon slds-input__icon_left slds-icon-text-default"
           >
             <use
               xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#warning"
@@ -34163,10 +32522,10 @@ exports[`Storyshots Input Read only 1`] = `
         Input Label
       </label>
       <div
-        className="slds-form-element__control slds-has-divider--bottom"
+        className="slds-form-element__control slds-has-divider_bottom"
       >
         <p
-          className="slds-text-body--regular slds-form-element__static"
+          className="slds-text-body_regular slds-form-element__static"
           id="input-$uuid$"
         >
           Read Only
@@ -34215,24 +32574,24 @@ exports[`Storyshots Input Read only with fixed text 1`] = `
         Input Label
       </label>
       <div
-        className="slds-form-element__control slds-has-divider--bottom"
+        className="slds-form-element__control slds-has-divider_bottom"
       >
         <div
           className="slds-form-element__control slds-input-has-fixed-addon"
         >
           <span
-            className="slds-text-body--regular slds-form-element__addon"
+            className="slds-text-body_regular slds-form-element__addon"
           >
             $
           </span>
           <p
-            className="slds-text-body--regular slds-form-element__static"
+            className="slds-text-body_regular slds-form-element__static"
             id="input-$uuid$"
           >
             Read Only
           </p>
           <span
-            className="slds-text-body--regular slds-form-element__addon"
+            className="slds-text-body_regular slds-form-element__addon"
           >
             %
           </span>
@@ -34345,7 +32704,7 @@ exports[`Storyshots Input With fixed text 1`] = `
           className="slds-form-element__control slds-input-has-fixed-addon"
         >
           <span
-            className="slds-text-body--regular slds-form-element__addon"
+            className="slds-text-body_regular slds-form-element__addon"
           >
             $
           </span>
@@ -34357,7 +32716,7 @@ exports[`Storyshots Input With fixed text 1`] = `
             placeholder="Placeholder Text"
           />
           <span
-            className="slds-text-body--regular slds-form-element__addon"
+            className="slds-text-body_regular slds-form-element__addon"
           >
             %
           </span>
@@ -34409,11 +32768,11 @@ exports[`Storyshots Input With icon to the left & right 1`] = `
         className="slds-form-element__control"
       >
         <div
-          className="slds-form-element__control slds-input-has-icon slds-input-has-icon--left-right slds-input-has-icon--left slds-input-has-icon--right"
+          className="slds-form-element__control slds-input-has-icon slds-input-has-icon_left-right slds-input-has-icon_left slds-input-has-icon_right"
         >
           <svg
             aria-hidden={true}
-            className="slds-icon slds-icon-text-default slds-input__icon slds-input__icon--left slds-icon-text-default"
+            className="slds-icon slds-icon-text-default slds-input__icon slds-input__icon_left slds-icon-text-default"
           >
             <use
               xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#search"
@@ -34428,7 +32787,7 @@ exports[`Storyshots Input With icon to the left & right 1`] = `
           />
           <svg
             aria-hidden={true}
-            className="slds-icon slds-icon-text-default slds-input__icon slds-input__icon--right slds-icon-text-default"
+            className="slds-icon slds-icon-text-default slds-input__icon slds-input__icon_right slds-icon-text-default"
           >
             <use
               xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#clear"
@@ -34482,11 +32841,11 @@ exports[`Storyshots Input With icon to the left 1`] = `
         className="slds-form-element__control"
       >
         <div
-          className="slds-form-element__control slds-input-has-icon slds-input-has-icon--left"
+          className="slds-form-element__control slds-input-has-icon slds-input-has-icon_left"
         >
           <svg
             aria-hidden={true}
-            className="slds-icon slds-icon-text-default slds-input__icon slds-input__icon--left slds-icon-text-default"
+            className="slds-icon slds-icon-text-default slds-input__icon slds-input__icon_left slds-icon-text-default"
           >
             <use
               xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#search"
@@ -34547,7 +32906,7 @@ exports[`Storyshots Input With icon to the right 1`] = `
         className="slds-form-element__control"
       >
         <div
-          className="slds-form-element__control slds-input-has-icon slds-input-has-icon--right"
+          className="slds-form-element__control slds-input-has-icon slds-input-has-icon_right"
         >
           <input
             className="slds-input"
@@ -34558,7 +32917,7 @@ exports[`Storyshots Input With icon to the right 1`] = `
           />
           <svg
             aria-hidden={true}
-            className="slds-icon slds-icon-text-default slds-input__icon slds-input__icon--right slds-icon-text-default"
+            className="slds-icon slds-icon-text-default slds-input__icon slds-input__icon_right slds-icon-text-default"
           >
             <use
               xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#search"
@@ -34618,7 +32977,7 @@ exports[`Storyshots Lookup Controlled 1`] = `
           data-typeahead={false}
         >
           <div
-            className="slds-grid slds-input-has-icon slds-input-has-icon--right"
+            className="slds-grid slds-input-has-icon slds-input-has-icon_right"
           >
             <input
               className="slds-input"
@@ -34630,7 +32989,7 @@ exports[`Storyshots Lookup Controlled 1`] = `
               value=""
             />
             <button
-              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
               onBlur={[Function]}
               onClick={[Function]}
               tabIndex={-1}
@@ -34701,7 +33060,7 @@ exports[`Storyshots Lookup Controlled with Multi Scope 1`] = `
           data-typeahead={false}
         >
           <div
-            className="slds-grid slds-form-element__control slds-box--border"
+            className="slds-grid slds-form-element__control slds-box_border"
             style={
               Object {
                 "WebkitFlexWrap": "nowrap",
@@ -34711,7 +33070,7 @@ exports[`Storyshots Lookup Controlled with Multi Scope 1`] = `
             }
           >
             <div
-              className="slds-grid slds-grid--align-center slds-grid--vertical-align-center react-slds-lookup-scope-selector"
+              className="slds-grid slds-grid_align-center slds-grid_vertical-align-center react-slds-lookup-scope-selector"
             >
               <div
                 className="slds-dropdown-trigger slds-button-space-left"
@@ -34727,7 +33086,7 @@ exports[`Storyshots Lookup Controlled with Multi Scope 1`] = `
                 >
                   <svg
                     aria-hidden={true}
-                    className="slds-icon slds-icon--x-small slds-icon-standard-account"
+                    className="slds-icon slds-icon_x-small slds-icon-standard-account"
                   >
                     <use
                       xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account"
@@ -34735,7 +33094,7 @@ exports[`Storyshots Lookup Controlled with Multi Scope 1`] = `
                   </svg>
                   <svg
                     aria-hidden={true}
-                    className="slds-button__icon slds-button__icon--right slds-button__icon--small"
+                    className="slds-button__icon slds-button__icon_right slds-button__icon_small"
                     pointerEvents="none"
                   >
                     <use
@@ -34746,10 +33105,10 @@ exports[`Storyshots Lookup Controlled with Multi Scope 1`] = `
               </div>
             </div>
             <div
-              className="slds-grid slds-input-has-icon slds-input-has-icon--right slds-col"
+              className="slds-grid slds-input-has-icon slds-input-has-icon_right slds-col"
             >
               <input
-                className="slds-input--bare"
+                className="slds-input_bare"
                 id="form-element-$uuid$"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -34758,7 +33117,7 @@ exports[`Storyshots Lookup Controlled with Multi Scope 1`] = `
                 value=""
               />
               <button
-                className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                 onBlur={[Function]}
                 onClick={[Function]}
                 tabIndex={-1}
@@ -34830,7 +33189,7 @@ exports[`Storyshots Lookup Controlled with knobs 1`] = `
           data-typeahead={false}
         >
           <div
-            className="slds-grid slds-input-has-icon slds-input-has-icon--right"
+            className="slds-grid slds-input-has-icon slds-input-has-icon_right"
           >
             <input
               className="slds-input"
@@ -34842,7 +33201,7 @@ exports[`Storyshots Lookup Controlled with knobs 1`] = `
               onSubmit={[Function]}
             />
             <button
-              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
               disabled={false}
               onBlur={[Function]}
               onClick={[Function]}
@@ -34914,7 +33273,7 @@ exports[`Storyshots Lookup Disabled 1`] = `
           data-typeahead={false}
         >
           <div
-            className="slds-grid slds-input-has-icon slds-input-has-icon--right"
+            className="slds-grid slds-input-has-icon slds-input-has-icon_right"
           >
             <input
               className="slds-input"
@@ -34926,7 +33285,7 @@ exports[`Storyshots Lookup Disabled 1`] = `
               onSubmit={[Function]}
             />
             <button
-              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
               disabled={true}
               onBlur={[Function]}
               onClick={[Function]}
@@ -35003,7 +33362,7 @@ exports[`Storyshots Lookup Error 1`] = `
           data-typeahead={false}
         >
           <div
-            className="slds-grid slds-input-has-icon slds-input-has-icon--right"
+            className="slds-grid slds-input-has-icon slds-input-has-icon_right"
           >
             <input
               className="slds-input"
@@ -35014,7 +33373,7 @@ exports[`Storyshots Lookup Error 1`] = `
               onSubmit={[Function]}
             />
             <button
-              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
               onBlur={[Function]}
               onClick={[Function]}
               tabIndex={-1}
@@ -35090,7 +33449,7 @@ exports[`Storyshots Lookup Multi Scope - Disabled 1`] = `
           data-typeahead={false}
         >
           <div
-            className="slds-grid slds-form-element__control slds-box--border react-slds-box-disabled"
+            className="slds-grid slds-form-element__control slds-box_border react-slds-box-disabled"
             style={
               Object {
                 "WebkitFlexWrap": "nowrap",
@@ -35100,7 +33459,7 @@ exports[`Storyshots Lookup Multi Scope - Disabled 1`] = `
             }
           >
             <div
-              className="slds-grid slds-grid--align-center slds-grid--vertical-align-center react-slds-lookup-scope-selector"
+              className="slds-grid slds-grid_align-center slds-grid_vertical-align-center react-slds-lookup-scope-selector"
             >
               <div
                 className="slds-dropdown-trigger slds-button-space-left"
@@ -35117,7 +33476,7 @@ exports[`Storyshots Lookup Multi Scope - Disabled 1`] = `
                 >
                   <svg
                     aria-hidden={true}
-                    className="slds-icon slds-icon--x-small slds-icon-standard-account"
+                    className="slds-icon slds-icon_x-small slds-icon-standard-account"
                   >
                     <use
                       xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account"
@@ -35125,7 +33484,7 @@ exports[`Storyshots Lookup Multi Scope - Disabled 1`] = `
                   </svg>
                   <svg
                     aria-hidden={true}
-                    className="slds-button__icon slds-button__icon--right slds-button__icon--small"
+                    className="slds-button__icon slds-button__icon_right slds-button__icon_small"
                     pointerEvents="none"
                   >
                     <use
@@ -35136,10 +33495,10 @@ exports[`Storyshots Lookup Multi Scope - Disabled 1`] = `
               </div>
             </div>
             <div
-              className="slds-grid slds-input-has-icon slds-input-has-icon--right slds-col"
+              className="slds-grid slds-input-has-icon slds-input-has-icon_right slds-col"
             >
               <input
-                className="slds-input--bare"
+                className="slds-input_bare"
                 disabled={true}
                 id="form-element-$uuid$"
                 onBlur={[Function]}
@@ -35148,7 +33507,7 @@ exports[`Storyshots Lookup Multi Scope - Disabled 1`] = `
                 onSubmit={[Function]}
               />
               <button
-                className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                 disabled={true}
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -35226,7 +33585,7 @@ exports[`Storyshots Lookup Multi Scope - Error 1`] = `
           data-typeahead={false}
         >
           <div
-            className="slds-grid slds-form-element__control slds-box--border"
+            className="slds-grid slds-form-element__control slds-box_border"
             style={
               Object {
                 "WebkitFlexWrap": "nowrap",
@@ -35236,7 +33595,7 @@ exports[`Storyshots Lookup Multi Scope - Error 1`] = `
             }
           >
             <div
-              className="slds-grid slds-grid--align-center slds-grid--vertical-align-center react-slds-lookup-scope-selector"
+              className="slds-grid slds-grid_align-center slds-grid_vertical-align-center react-slds-lookup-scope-selector"
             >
               <div
                 className="slds-dropdown-trigger slds-button-space-left"
@@ -35252,7 +33611,7 @@ exports[`Storyshots Lookup Multi Scope - Error 1`] = `
                 >
                   <svg
                     aria-hidden={true}
-                    className="slds-icon slds-icon--x-small slds-icon-standard-account"
+                    className="slds-icon slds-icon_x-small slds-icon-standard-account"
                   >
                     <use
                       xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account"
@@ -35260,7 +33619,7 @@ exports[`Storyshots Lookup Multi Scope - Error 1`] = `
                   </svg>
                   <svg
                     aria-hidden={true}
-                    className="slds-button__icon slds-button__icon--right slds-button__icon--small"
+                    className="slds-button__icon slds-button__icon_right slds-button__icon_small"
                     pointerEvents="none"
                   >
                     <use
@@ -35271,10 +33630,10 @@ exports[`Storyshots Lookup Multi Scope - Error 1`] = `
               </div>
             </div>
             <div
-              className="slds-grid slds-input-has-icon slds-input-has-icon--right slds-col"
+              className="slds-grid slds-input-has-icon slds-input-has-icon_right slds-col"
             >
               <input
-                className="slds-input--bare"
+                className="slds-input_bare"
                 id="form-element-$uuid$"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -35282,7 +33641,7 @@ exports[`Storyshots Lookup Multi Scope - Error 1`] = `
                 onSubmit={[Function]}
               />
               <button
-                className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                 onBlur={[Function]}
                 onClick={[Function]}
                 tabIndex={-1}
@@ -35364,7 +33723,7 @@ exports[`Storyshots Lookup Multi Scope - Required 1`] = `
           data-typeahead={false}
         >
           <div
-            className="slds-grid slds-form-element__control slds-box--border"
+            className="slds-grid slds-form-element__control slds-box_border"
             style={
               Object {
                 "WebkitFlexWrap": "nowrap",
@@ -35374,7 +33733,7 @@ exports[`Storyshots Lookup Multi Scope - Required 1`] = `
             }
           >
             <div
-              className="slds-grid slds-grid--align-center slds-grid--vertical-align-center react-slds-lookup-scope-selector"
+              className="slds-grid slds-grid_align-center slds-grid_vertical-align-center react-slds-lookup-scope-selector"
             >
               <div
                 className="slds-dropdown-trigger slds-button-space-left"
@@ -35390,7 +33749,7 @@ exports[`Storyshots Lookup Multi Scope - Required 1`] = `
                 >
                   <svg
                     aria-hidden={true}
-                    className="slds-icon slds-icon--x-small slds-icon-standard-account"
+                    className="slds-icon slds-icon_x-small slds-icon-standard-account"
                   >
                     <use
                       xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account"
@@ -35398,7 +33757,7 @@ exports[`Storyshots Lookup Multi Scope - Required 1`] = `
                   </svg>
                   <svg
                     aria-hidden={true}
-                    className="slds-button__icon slds-button__icon--right slds-button__icon--small"
+                    className="slds-button__icon slds-button__icon_right slds-button__icon_small"
                     pointerEvents="none"
                   >
                     <use
@@ -35409,10 +33768,10 @@ exports[`Storyshots Lookup Multi Scope - Required 1`] = `
               </div>
             </div>
             <div
-              className="slds-grid slds-input-has-icon slds-input-has-icon--right slds-col"
+              className="slds-grid slds-input-has-icon slds-input-has-icon_right slds-col"
             >
               <input
-                className="slds-input--bare"
+                className="slds-input_bare"
                 id="form-element-$uuid$"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -35420,7 +33779,7 @@ exports[`Storyshots Lookup Multi Scope - Required 1`] = `
                 onSubmit={[Function]}
               />
               <button
-                className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                 onBlur={[Function]}
                 onClick={[Function]}
                 tabIndex={-1}
@@ -35492,7 +33851,7 @@ exports[`Storyshots Lookup Multi Scope 1`] = `
           data-typeahead={false}
         >
           <div
-            className="slds-grid slds-form-element__control slds-box--border"
+            className="slds-grid slds-form-element__control slds-box_border"
             style={
               Object {
                 "WebkitFlexWrap": "nowrap",
@@ -35502,7 +33861,7 @@ exports[`Storyshots Lookup Multi Scope 1`] = `
             }
           >
             <div
-              className="slds-grid slds-grid--align-center slds-grid--vertical-align-center react-slds-lookup-scope-selector"
+              className="slds-grid slds-grid_align-center slds-grid_vertical-align-center react-slds-lookup-scope-selector"
             >
               <div
                 className="slds-dropdown-trigger slds-button-space-left"
@@ -35518,7 +33877,7 @@ exports[`Storyshots Lookup Multi Scope 1`] = `
                 >
                   <svg
                     aria-hidden={true}
-                    className="slds-icon slds-icon--x-small slds-icon-standard-account"
+                    className="slds-icon slds-icon_x-small slds-icon-standard-account"
                   >
                     <use
                       xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account"
@@ -35526,7 +33885,7 @@ exports[`Storyshots Lookup Multi Scope 1`] = `
                   </svg>
                   <svg
                     aria-hidden={true}
-                    className="slds-button__icon slds-button__icon--right slds-button__icon--small"
+                    className="slds-button__icon slds-button__icon_right slds-button__icon_small"
                     pointerEvents="none"
                   >
                     <use
@@ -35537,10 +33896,10 @@ exports[`Storyshots Lookup Multi Scope 1`] = `
               </div>
             </div>
             <div
-              className="slds-grid slds-input-has-icon slds-input-has-icon--right slds-col"
+              className="slds-grid slds-input-has-icon slds-input-has-icon_right slds-col"
             >
               <input
-                className="slds-input--bare"
+                className="slds-input_bare"
                 id="form-element-$uuid$"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -35549,7 +33908,7 @@ exports[`Storyshots Lookup Multi Scope 1`] = `
                 value="A"
               />
               <button
-                className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                 onBlur={[Function]}
                 onClick={[Function]}
                 tabIndex={-1}
@@ -35628,7 +33987,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
             data-typeahead={false}
           >
             <div
-              className="slds-grid slds-input-has-icon slds-input-has-icon--right"
+              className="slds-grid slds-input-has-icon slds-input-has-icon_right"
             >
               <input
                 className="slds-input"
@@ -35640,7 +33999,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                 value="A"
               />
               <button
-                className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                 onBlur={[Function]}
                 onClick={[Function]}
                 tabIndex={-1}
@@ -35694,7 +34053,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -35745,7 +34104,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -35796,7 +34155,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -35847,7 +34206,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -35898,7 +34257,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -35949,7 +34308,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36000,7 +34359,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36051,7 +34410,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36102,7 +34461,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36153,7 +34512,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36204,7 +34563,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36255,7 +34614,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36306,7 +34665,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36357,7 +34716,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36408,7 +34767,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36459,7 +34818,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36510,7 +34869,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36561,7 +34920,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36612,7 +34971,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36663,7 +35022,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36714,7 +35073,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36765,7 +35124,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36816,7 +35175,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36867,7 +35226,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36918,7 +35277,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -36969,7 +35328,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37020,7 +35379,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37071,7 +35430,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37122,7 +35481,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37173,7 +35532,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37224,7 +35583,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37275,7 +35634,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37326,7 +35685,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37377,7 +35736,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37428,7 +35787,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37479,7 +35838,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37530,7 +35889,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37581,7 +35940,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37632,7 +35991,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37683,7 +36042,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37734,7 +36093,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37785,7 +36144,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37836,7 +36195,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37887,7 +36246,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37938,7 +36297,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -37989,7 +36348,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -38040,7 +36399,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -38091,7 +36450,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -38142,7 +36501,7 @@ exports[`Storyshots Lookup Opened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -38227,7 +36586,7 @@ exports[`Storyshots Lookup Opened - In Loading 1`] = `
           data-typeahead={false}
         >
           <div
-            className="slds-grid slds-input-has-icon slds-input-has-icon--right"
+            className="slds-grid slds-input-has-icon slds-input-has-icon_right"
           >
             <input
               className="slds-input"
@@ -38239,7 +36598,7 @@ exports[`Storyshots Lookup Opened - In Loading 1`] = `
               value="A"
             />
             <button
-              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
               onBlur={[Function]}
               onClick={[Function]}
               tabIndex={-1}
@@ -38280,7 +36639,7 @@ exports[`Storyshots Lookup Opened - In Loading 1`] = `
               >
                 <div
                   aria-hidden="false"
-                  className="slds-spinner slds-spinner--small"
+                  className="slds-spinner slds-spinner_small"
                   role="alert"
                   style={
                     Object {
@@ -38359,7 +36718,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
             data-typeahead={false}
           >
             <div
-              className="slds-grid slds-input-has-icon slds-input-has-icon--right"
+              className="slds-grid slds-input-has-icon slds-input-has-icon_right"
             >
               <input
                 className="slds-input"
@@ -38371,7 +36730,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                 value="A"
               />
               <button
-                className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                 onBlur={[Function]}
                 onClick={[Function]}
                 tabIndex={-1}
@@ -38408,7 +36767,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                 >
                   <svg
                     aria-hidden={true}
-                    className="slds-button__icon slds-button__icon--left"
+                    className="slds-button__icon slds-button__icon_left"
                     pointerEvents="none"
                   >
                     <use
@@ -38445,7 +36804,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -38496,7 +36855,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -38547,7 +36906,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -38598,7 +36957,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -38649,7 +37008,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -38700,7 +37059,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -38751,7 +37110,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -38802,7 +37161,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -38853,7 +37212,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -38904,7 +37263,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -38955,7 +37314,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39006,7 +37365,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39057,7 +37416,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39108,7 +37467,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39159,7 +37518,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39210,7 +37569,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39261,7 +37620,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39312,7 +37671,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39363,7 +37722,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39414,7 +37773,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39465,7 +37824,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39516,7 +37875,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39567,7 +37926,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39618,7 +37977,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39669,7 +38028,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39720,7 +38079,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39771,7 +38130,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39822,7 +38181,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39873,7 +38232,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39924,7 +38283,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -39975,7 +38334,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40026,7 +38385,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40077,7 +38436,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40128,7 +38487,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40179,7 +38538,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40230,7 +38589,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40281,7 +38640,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40332,7 +38691,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40383,7 +38742,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40434,7 +38793,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40485,7 +38844,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40536,7 +38895,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40587,7 +38946,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40638,7 +38997,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40689,7 +39048,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40740,7 +39099,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40791,7 +39150,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40842,7 +39201,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40893,7 +39252,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -40932,7 +39291,7 @@ exports[`Storyshots Lookup Opened - With list header/footer 1`] = `
                 >
                   <svg
                     aria-hidden={true}
-                    className="slds-button__icon slds-button__icon--left"
+                    className="slds-button__icon slds-button__icon_left"
                     pointerEvents="none"
                   >
                     <use
@@ -41003,7 +39362,7 @@ exports[`Storyshots Lookup Required 1`] = `
           data-typeahead={false}
         >
           <div
-            className="slds-grid slds-input-has-icon slds-input-has-icon--right"
+            className="slds-grid slds-input-has-icon slds-input-has-icon_right"
           >
             <input
               className="slds-input"
@@ -41014,7 +39373,7 @@ exports[`Storyshots Lookup Required 1`] = `
               onSubmit={[Function]}
             />
             <button
-              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
               onBlur={[Function]}
               onClick={[Function]}
               tabIndex={-1}
@@ -41085,7 +39444,7 @@ exports[`Storyshots Lookup Uncontrolled 1`] = `
           data-typeahead={false}
         >
           <div
-            className="slds-grid slds-input-has-icon slds-input-has-icon--right"
+            className="slds-grid slds-input-has-icon slds-input-has-icon_right"
           >
             <input
               className="slds-input"
@@ -41097,7 +39456,7 @@ exports[`Storyshots Lookup Uncontrolled 1`] = `
               value="A"
             />
             <button
-              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
               onBlur={[Function]}
               onClick={[Function]}
               tabIndex={-1}
@@ -41168,7 +39527,7 @@ exports[`Storyshots Lookup Uncontrolled with Multi Scope 1`] = `
           data-typeahead={false}
         >
           <div
-            className="slds-grid slds-form-element__control slds-box--border"
+            className="slds-grid slds-form-element__control slds-box_border"
             style={
               Object {
                 "WebkitFlexWrap": "nowrap",
@@ -41178,7 +39537,7 @@ exports[`Storyshots Lookup Uncontrolled with Multi Scope 1`] = `
             }
           >
             <div
-              className="slds-grid slds-grid--align-center slds-grid--vertical-align-center react-slds-lookup-scope-selector"
+              className="slds-grid slds-grid_align-center slds-grid_vertical-align-center react-slds-lookup-scope-selector"
             >
               <div
                 className="slds-dropdown-trigger slds-button-space-left"
@@ -41194,7 +39553,7 @@ exports[`Storyshots Lookup Uncontrolled with Multi Scope 1`] = `
                 >
                   <svg
                     aria-hidden={true}
-                    className="slds-icon slds-icon--x-small slds-icon-standard-opportunity"
+                    className="slds-icon slds-icon_x-small slds-icon-standard-opportunity"
                   >
                     <use
                       xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity"
@@ -41202,7 +39561,7 @@ exports[`Storyshots Lookup Uncontrolled with Multi Scope 1`] = `
                   </svg>
                   <svg
                     aria-hidden={true}
-                    className="slds-button__icon slds-button__icon--right slds-button__icon--small"
+                    className="slds-button__icon slds-button__icon_right slds-button__icon_small"
                     pointerEvents="none"
                   >
                     <use
@@ -41213,10 +39572,10 @@ exports[`Storyshots Lookup Uncontrolled with Multi Scope 1`] = `
               </div>
             </div>
             <div
-              className="slds-grid slds-input-has-icon slds-input-has-icon--right slds-col"
+              className="slds-grid slds-input-has-icon slds-input-has-icon_right slds-col"
             >
               <input
-                className="slds-input--bare"
+                className="slds-input_bare"
                 id="form-element-$uuid$"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -41225,7 +39584,7 @@ exports[`Storyshots Lookup Uncontrolled with Multi Scope 1`] = `
                 value="A"
               />
               <button
-                className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                 onBlur={[Function]}
                 onClick={[Function]}
                 tabIndex={-1}
@@ -41297,7 +39656,7 @@ exports[`Storyshots Lookup With search icon in left 1`] = `
           data-typeahead={false}
         >
           <div
-            className="slds-grid slds-input-has-icon slds-input-has-icon--left"
+            className="slds-grid slds-input-has-icon slds-input-has-icon_left"
           >
             <input
               className="slds-input"
@@ -41309,7 +39668,7 @@ exports[`Storyshots Lookup With search icon in left 1`] = `
               value="A"
             />
             <button
-              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
               onBlur={[Function]}
               onClick={[Function]}
               tabIndex={-1}
@@ -41380,7 +39739,7 @@ exports[`Storyshots Lookup With search text 1`] = `
           data-typeahead={false}
         >
           <div
-            className="slds-grid slds-input-has-icon slds-input-has-icon--right"
+            className="slds-grid slds-input-has-icon slds-input-has-icon_right"
           >
             <input
               className="slds-input"
@@ -41392,7 +39751,7 @@ exports[`Storyshots Lookup With search text 1`] = `
               value="A"
             />
             <button
-              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
               onBlur={[Function]}
               onClick={[Function]}
               tabIndex={-1}
@@ -41487,7 +39846,7 @@ exports[`Storyshots Lookup With selection 1`] = `
                   Apple Inc.
                 </span>
                 <button
-                  className="slds-pill__remove slds-button slds-button--icon-bare"
+                  className="slds-pill__remove slds-button slds-button_icon-bare"
                   onClick={[Function]}
                   tabIndex={-1}
                   type="button"
@@ -41571,7 +39930,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
             data-typeahead={false}
           >
             <div
-              className="slds-grid slds-input-has-icon slds-input-has-icon--right"
+              className="slds-grid slds-input-has-icon slds-input-has-icon_right"
             >
               <input
                 className="slds-input"
@@ -41583,7 +39942,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                 value="A"
               />
               <button
-                className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                 onBlur={[Function]}
                 onClick={[Function]}
                 tabIndex={-1}
@@ -41637,7 +39996,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -41688,7 +40047,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -41739,7 +40098,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -41790,7 +40149,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -41841,7 +40200,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -41892,7 +40251,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -41943,7 +40302,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -41994,7 +40353,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42045,7 +40404,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42096,7 +40455,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42147,7 +40506,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42198,7 +40557,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42249,7 +40608,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42300,7 +40659,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42351,7 +40710,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42402,7 +40761,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42453,7 +40812,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42504,7 +40863,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42555,7 +40914,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42606,7 +40965,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42657,7 +41016,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42708,7 +41067,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42759,7 +41118,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42810,7 +41169,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42861,7 +41220,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42912,7 +41271,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -42963,7 +41322,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43014,7 +41373,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43065,7 +41424,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43116,7 +41475,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43167,7 +41526,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43218,7 +41577,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43269,7 +41628,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43320,7 +41679,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43371,7 +41730,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43422,7 +41781,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43473,7 +41832,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43524,7 +41883,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43575,7 +41934,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43626,7 +41985,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43677,7 +42036,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43728,7 +42087,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43779,7 +42138,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43830,7 +42189,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43881,7 +42240,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43932,7 +42291,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -43983,7 +42342,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -44034,7 +42393,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -44085,7 +42444,7 @@ exports[`Storyshots Lookup defaultOpened - Active 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -44170,7 +42529,7 @@ exports[`Storyshots Lookup defaultOpened - In Loading 1`] = `
           data-typeahead={false}
         >
           <div
-            className="slds-grid slds-input-has-icon slds-input-has-icon--right"
+            className="slds-grid slds-input-has-icon slds-input-has-icon_right"
           >
             <input
               className="slds-input"
@@ -44182,7 +42541,7 @@ exports[`Storyshots Lookup defaultOpened - In Loading 1`] = `
               value="A"
             />
             <button
-              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
               onBlur={[Function]}
               onClick={[Function]}
               tabIndex={-1}
@@ -44223,7 +42582,7 @@ exports[`Storyshots Lookup defaultOpened - In Loading 1`] = `
               >
                 <div
                   aria-hidden="false"
-                  className="slds-spinner slds-spinner--small"
+                  className="slds-spinner slds-spinner_small"
                   role="alert"
                   style={
                     Object {
@@ -44302,7 +42661,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
             data-typeahead={false}
           >
             <div
-              className="slds-grid slds-input-has-icon slds-input-has-icon--right"
+              className="slds-grid slds-input-has-icon slds-input-has-icon_right"
             >
               <input
                 className="slds-input"
@@ -44314,7 +42673,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                 value="A"
               />
               <button
-                className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                 onBlur={[Function]}
                 onClick={[Function]}
                 tabIndex={-1}
@@ -44351,7 +42710,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                 >
                   <svg
                     aria-hidden={true}
-                    className="slds-button__icon slds-button__icon--left"
+                    className="slds-button__icon slds-button__icon_left"
                     pointerEvents="none"
                   >
                     <use
@@ -44388,7 +42747,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -44439,7 +42798,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -44490,7 +42849,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -44541,7 +42900,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -44592,7 +42951,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -44643,7 +43002,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -44694,7 +43053,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -44745,7 +43104,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -44796,7 +43155,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -44847,7 +43206,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -44898,7 +43257,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -44949,7 +43308,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45000,7 +43359,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45051,7 +43410,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45102,7 +43461,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45153,7 +43512,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45204,7 +43563,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45255,7 +43614,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45306,7 +43665,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45357,7 +43716,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45408,7 +43767,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45459,7 +43818,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45510,7 +43869,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45561,7 +43920,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45612,7 +43971,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45663,7 +44022,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45714,7 +44073,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45765,7 +44124,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45816,7 +44175,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45867,7 +44226,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45918,7 +44277,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -45969,7 +44328,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -46020,7 +44379,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -46071,7 +44430,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -46122,7 +44481,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -46173,7 +44532,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -46224,7 +44583,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -46275,7 +44634,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -46326,7 +44685,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -46377,7 +44736,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -46428,7 +44787,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -46479,7 +44838,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -46530,7 +44889,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -46581,7 +44940,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -46632,7 +44991,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -46683,7 +45042,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -46734,7 +45093,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -46785,7 +45144,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -46836,7 +45195,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--small slds-icon-standard-account slds-m-right--x-small"
+                        className="slds-icon slds-icon_small slds-icon-standard-account slds-m-right_x-small"
                         style={
                           Object {
                             "minWidth": "1.5rem",
@@ -46875,7 +45234,7 @@ exports[`Storyshots Lookup defaultOpened - With list header/footer 1`] = `
                 >
                   <svg
                     aria-hidden={true}
-                    className="slds-button__icon slds-button__icon--left"
+                    className="slds-button__icon slds-button__icon_left"
                     pointerEvents="none"
                   >
                     <use
@@ -46948,7 +45307,7 @@ Mollit officia cillum Lorem ullamco minim nostrud elit officia tempor esse quis.
         </p>
       </div>
       <div
-        className="slds-media__figure slds-media__figure--reverse"
+        className="slds-media__figure slds-media__figure_reverse"
       >
         <img
           alt="Placeholder"
@@ -46985,77 +45344,6 @@ Mollit officia cillum Lorem ullamco minim nostrud elit officia tempor esse quis.
 </div>
 `;
 
-exports[`Storyshots MediaObject Figure - Center 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div
-      className="slds-media"
-    >
-      <div
-        className="slds-media__figure slds-media__figure_stacked"
-      >
-        <img
-          alt="Placeholder"
-          src="/assets/images/avatar1.jpg"
-          style={
-            Object {
-              "height": 100,
-            }
-          }
-        />
-      </div>
-      <div
-        className="slds-media__figure"
-      >
-        <img
-          alt="Placeholder"
-          src="/assets/images/avatar2.jpg"
-          style={
-            Object {
-              "height": 100,
-            }
-          }
-        />
-      </div>
-      <div
-        className="slds-media__body"
-      >
-        <p>
-          Sit nulla est ex deserunt exercitation anim occaecat.
-Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi.
-Mollit officia cillum Lorem ullamco minim nostrud elit officia tempor esse quis.
-        </p>
-      </div>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        Media Object with figure in right
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Storyshots MediaObject Figure - Reverse 1`] = `
 <div
   className="content-wrapper"
@@ -47077,7 +45365,7 @@ Mollit officia cillum Lorem ullamco minim nostrud elit officia tempor esse quis.
         </p>
       </div>
       <div
-        className="slds-media__figure slds-media__figure--reverse"
+        className="slds-media__figure slds-media__figure_reverse"
       >
         <img
           alt="Placeholder"
@@ -47197,7 +45485,7 @@ exports[`Storyshots Modal Controlled with knobs 1`] = `
             className="slds-modal__header"
           >
             <h2
-              className="slds-text-heading--medium"
+              className="slds-text-heading_medium"
             >
               
             </h2>
@@ -47206,7 +45494,7 @@ exports[`Storyshots Modal Controlled with knobs 1`] = `
             className="slds-modal__content"
           >
             <div
-              className="slds-p-around--small"
+              className="slds-p-around_small"
             >
               <p>
                 Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi. Mollit officia cillum Lorem ullamco minim nostrud elit officia tempor esse quis. Cillum sunt ad dolore quis aute consequat ipsum magna exercitation reprehenderit magna. Tempor cupidatat consequat elit dolor adipisicing.
@@ -47220,14 +45508,14 @@ exports[`Storyshots Modal Controlled with knobs 1`] = `
             className="slds-modal__footer"
           >
             <button
-              className="slds-button slds-button--neutral"
+              className="slds-button slds-button_neutral"
               onClick={[Function]}
               type="button"
             >
               Cancel
             </button>
             <button
-              className="slds-button slds-button--brand"
+              className="slds-button slds-button_brand"
               onClick={[Function]}
               type="button"
             >
@@ -47292,18 +45580,18 @@ exports[`Storyshots Modal Default 1`] = `
             className="slds-modal__header"
           >
             <h2
-              className="slds-text-heading--medium"
+              className="slds-text-heading_medium"
             >
               Default Modal
             </h2>
             <button
-              className="slds-modal__close slds-button slds-button--icon-inverse"
+              className="slds-modal__close slds-button slds-button_icon-inverse"
               onClick={[Function]}
               type="button"
             >
               <svg
                 aria-hidden={true}
-                className="slds-button__icon slds-button__icon--large slds-button__icon--inverse"
+                className="slds-button__icon slds-button__icon_large slds-button__icon_inverse"
                 pointerEvents="none"
               >
                 <use
@@ -47318,7 +45606,7 @@ exports[`Storyshots Modal Default 1`] = `
             </button>
           </div>
           <div
-            className="slds-p-around--small slds-modal__content"
+            className="slds-p-around_small slds-modal__content"
           >
             <p>
               Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi. Mollit officia cillum Lorem ullamco minim nostrud elit officia tempor esse quis. Cillum sunt ad dolore quis aute consequat ipsum magna exercitation reprehenderit magna. Tempor cupidatat consequat elit dolor adipisicing.
@@ -47331,14 +45619,14 @@ exports[`Storyshots Modal Default 1`] = `
             className="slds-modal__footer"
           >
             <button
-              className="slds-button slds-button--neutral"
+              className="slds-button slds-button_neutral"
               onClick={[Function]}
               type="button"
             >
               Cancel
             </button>
             <button
-              className="slds-button slds-button--brand"
+              className="slds-button slds-button_brand"
               onClick={[Function]}
               type="button"
             >
@@ -47514,18 +45802,18 @@ exports[`Storyshots Modal Form elements 1`] = `
             className="slds-modal__header"
           >
             <h2
-              className="slds-text-heading--medium"
+              className="slds-text-heading_medium"
             >
               Modal Form
             </h2>
             <button
-              className="slds-modal__close slds-button slds-button--icon-inverse"
+              className="slds-modal__close slds-button slds-button_icon-inverse"
               onClick={[Function]}
               type="button"
             >
               <svg
                 aria-hidden={true}
-                className="slds-button__icon slds-button__icon--large slds-button__icon--inverse"
+                className="slds-button__icon slds-button__icon_large slds-button__icon_inverse"
                 pointerEvents="none"
               >
                 <use
@@ -47540,13 +45828,13 @@ exports[`Storyshots Modal Form elements 1`] = `
             </button>
           </div>
           <div
-            className="slds-p-around--small slds-modal__content"
+            className="slds-p-around_small slds-modal__content"
           >
             <form
-              className="slds-form--compound"
+              className="slds-form_compound"
             >
               <fieldset
-                className="slds-form--compound"
+                className="slds-form_compound"
               >
                 <legend
                   className="slds-form-element__label"
@@ -47560,7 +45848,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                     className="slds-form-element__row"
                   >
                     <div
-                      className="slds-form-element slds-size--1-of-2"
+                      className="slds-form-element slds-size_1-of-2"
                     >
                       <label
                         className="slds-form-element__label"
@@ -47581,7 +45869,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                       </div>
                     </div>
                     <div
-                      className="slds-form-element slds-size--1-of-2"
+                      className="slds-form-element slds-size_1-of-2"
                     >
                       <label
                         className="slds-form-element__label"
@@ -47605,7 +45893,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                 </div>
               </fieldset>
               <fieldset
-                className="slds-form--compound"
+                className="slds-form_compound"
               >
                 <legend
                   className="slds-form-element__label"
@@ -47619,7 +45907,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                     className="slds-form-element__row"
                   >
                     <div
-                      className="slds-form-element slds-size--1-of-2"
+                      className="slds-form-element slds-size_1-of-2"
                     >
                       <label
                         className="slds-form-element__label"
@@ -47634,7 +45922,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                           className="slds-dropdown-trigger"
                         >
                           <div
-                            className="slds-input-has-icon slds-input-has-icon--right"
+                            className="slds-input-has-icon slds-input-has-icon_right"
                           >
                             <input
                               className="slds-input"
@@ -47644,7 +45932,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                               onKeyDown={[Function]}
                             />
                             <button
-                              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                               onBlur={[Function]}
                               onClick={[Function]}
                               tabIndex={-1}
@@ -47665,7 +45953,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                       </div>
                     </div>
                     <div
-                      className="slds-form-element slds-size--1-of-2"
+                      className="slds-form-element slds-size_1-of-2"
                     >
                       <label
                         className="slds-form-element__label"
@@ -47680,7 +45968,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                           className="slds-dropdown-trigger"
                         >
                           <div
-                            className="slds-input-has-icon slds-input-has-icon--right"
+                            className="slds-input-has-icon slds-input-has-icon_right"
                           >
                             <input
                               className="slds-input"
@@ -47690,7 +45978,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                               onKeyDown={[Function]}
                             />
                             <button
-                              className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                              className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                               onBlur={[Function]}
                               onClick={[Function]}
                               tabIndex={-1}
@@ -47717,7 +46005,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                 className="slds-form-element__row"
               >
                 <div
-                  className="slds-form-element slds-size--1-of-1"
+                  className="slds-form-element slds-size_1-of-1"
                 >
                   <label
                     className="slds-form-element__label"
@@ -47732,7 +46020,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                       className="slds-dropdown-trigger"
                     >
                       <div
-                        className="slds-input-has-icon slds-input-has-icon--right"
+                        className="slds-input-has-icon slds-input-has-icon_right"
                       >
                         <input
                           className="slds-input"
@@ -47742,7 +46030,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                           onKeyDown={[Function]}
                         />
                         <button
-                          className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                          className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                           onBlur={[Function]}
                           onClick={[Function]}
                           tabIndex={-1}
@@ -47767,7 +46055,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                 className="slds-form-element__row"
               >
                 <div
-                  className="slds-form-element slds-size--1-of-2"
+                  className="slds-form-element slds-size_1-of-2"
                 >
                   <label
                     className="slds-form-element__label"
@@ -47782,7 +46070,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                       className="slds-picklist slds-dropdown-trigger"
                     >
                       <button
-                        className="slds-picklist__label slds-button slds-button--neutral"
+                        className="slds-picklist__label slds-button slds-button_neutral"
                         id="form-element-$uuid$"
                         onBlur={[Function]}
                         onClick={[Function]}
@@ -47815,7 +46103,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                   </div>
                 </div>
                 <div
-                  className="slds-form-element slds-size--1-of-2"
+                  className="slds-form-element slds-size_1-of-2"
                 >
                   <label
                     className="slds-form-element__label"
@@ -47833,7 +46121,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                       data-typeahead={false}
                     >
                       <div
-                        className="slds-grid slds-input-has-icon slds-input-has-icon--right"
+                        className="slds-grid slds-input-has-icon slds-input-has-icon_right"
                       >
                         <input
                           className="slds-input"
@@ -47844,7 +46132,7 @@ exports[`Storyshots Modal Form elements 1`] = `
                           onSubmit={[Function]}
                         />
                         <button
-                          className="slds-input__icon slds-input__icon_right slds-button slds-button--icon"
+                          className="slds-input__icon slds-input__icon_right slds-button slds-button_icon"
                           onBlur={[Function]}
                           onClick={[Function]}
                           tabIndex={-1}
@@ -47871,14 +46159,14 @@ exports[`Storyshots Modal Form elements 1`] = `
             className="slds-modal__footer"
           >
             <button
-              className="slds-button slds-button--neutral"
+              className="slds-button slds-button_neutral"
               onClick={[Function]}
               type="button"
             >
               Cancel
             </button>
             <button
-              className="slds-button slds-button--brand"
+              className="slds-button slds-button_brand"
               onClick={[Function]}
               type="button"
             >
@@ -47933,7 +46221,7 @@ exports[`Storyshots Modal Large 1`] = `
     <div>
       <div
         aria-hidden={false}
-        className="slds-modal slds-fade-in-open slds-modal--large"
+        className="slds-modal slds-fade-in-open slds-modal_large"
         role="dialog"
       >
         <div
@@ -47943,18 +46231,18 @@ exports[`Storyshots Modal Large 1`] = `
             className="slds-modal__header"
           >
             <h2
-              className="slds-text-heading--medium"
+              className="slds-text-heading_medium"
             >
               Large Size Modal
             </h2>
             <button
-              className="slds-modal__close slds-button slds-button--icon-inverse"
+              className="slds-modal__close slds-button slds-button_icon-inverse"
               onClick={[Function]}
               type="button"
             >
               <svg
                 aria-hidden={true}
-                className="slds-button__icon slds-button__icon--large slds-button__icon--inverse"
+                className="slds-button__icon slds-button__icon_large slds-button__icon_inverse"
                 pointerEvents="none"
               >
                 <use
@@ -47969,7 +46257,7 @@ exports[`Storyshots Modal Large 1`] = `
             </button>
           </div>
           <div
-            className="slds-p-around--small slds-modal__content"
+            className="slds-p-around_small slds-modal__content"
           >
             <p>
               Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi. Mollit officia cillum Lorem ullamco minim nostrud elit officia tempor esse quis. Cillum sunt ad dolore quis aute consequat ipsum magna exercitation reprehenderit magna. Tempor cupidatat consequat elit dolor adipisicing.
@@ -47982,14 +46270,14 @@ exports[`Storyshots Modal Large 1`] = `
             className="slds-modal__footer"
           >
             <button
-              className="slds-button slds-button--neutral"
+              className="slds-button slds-button_neutral"
               onClick={[Function]}
               type="button"
             >
               Cancel
             </button>
             <button
-              className="slds-button slds-button--brand"
+              className="slds-button slds-button_brand"
               onClick={[Function]}
               type="button"
             >
@@ -48154,7 +46442,7 @@ exports[`Storyshots Notification Alert - Default 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-notify slds-notify--alert slds-theme--alert-texture"
+      className="slds-notify slds-notify_alert slds-theme_alert-texture"
       role="alert"
     >
       <h2>
@@ -48194,17 +46482,17 @@ exports[`Storyshots Notification Alert - Error 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-notify slds-notify--alert slds-theme--error slds-theme--alert-texture"
+      className="slds-notify slds-notify_alert slds-theme_error slds-theme_alert-texture"
       role="alert"
     >
       <button
-        className="slds-notify__close slds-button slds-button--icon-inverse"
+        className="slds-notify__close slds-button slds-button_icon-inverse"
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="slds-button__icon slds-button__icon--small slds-button__icon--inverse"
+          className="slds-button__icon slds-button__icon_small slds-button__icon_inverse"
           pointerEvents="none"
         >
           <use
@@ -48220,7 +46508,7 @@ exports[`Storyshots Notification Alert - Error 1`] = `
       <h2>
         <svg
           aria-hidden={true}
-          className="slds-icon slds-icon--small slds-m-right--x-small"
+          className="slds-icon slds-icon_small slds-m-right_x-small"
         >
           <use
             xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#ban"
@@ -48266,17 +46554,17 @@ exports[`Storyshots Notification Alert - Info 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-notify slds-notify--alert slds-theme--info slds-theme--alert-texture"
+      className="slds-notify slds-notify_alert slds-theme_info slds-theme_alert-texture"
       role="alert"
     >
       <button
-        className="slds-notify__close slds-button slds-button--icon-inverse"
+        className="slds-notify__close slds-button slds-button_icon-inverse"
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="slds-button__icon slds-button__icon--small slds-button__icon--inverse"
+          className="slds-button__icon slds-button__icon_small slds-button__icon_inverse"
           pointerEvents="none"
         >
           <use
@@ -48292,7 +46580,7 @@ exports[`Storyshots Notification Alert - Info 1`] = `
       <h2>
         <svg
           aria-hidden={true}
-          className="slds-icon slds-icon--small slds-m-right--x-small"
+          className="slds-icon slds-icon_small slds-m-right_x-small"
         >
           <use
             xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#info"
@@ -48338,17 +46626,17 @@ exports[`Storyshots Notification Alert - Success 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-notify slds-notify--alert slds-theme--success slds-theme--alert-texture"
+      className="slds-notify slds-notify_alert slds-theme_success slds-theme_alert-texture"
       role="alert"
     >
       <button
-        className="slds-notify__close slds-button slds-button--icon-inverse"
+        className="slds-notify__close slds-button slds-button_icon-inverse"
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="slds-button__icon slds-button__icon--small slds-button__icon--inverse"
+          className="slds-button__icon slds-button__icon_small slds-button__icon_inverse"
           pointerEvents="none"
         >
           <use
@@ -48364,7 +46652,7 @@ exports[`Storyshots Notification Alert - Success 1`] = `
       <h2>
         <svg
           aria-hidden={true}
-          className="slds-icon slds-icon--small slds-m-right--x-small"
+          className="slds-icon slds-icon_small slds-m-right_x-small"
         >
           <use
             xlinkHref="/assets/icons/custom-sprite/svg/symbols.svg#custom19"
@@ -48410,17 +46698,17 @@ exports[`Storyshots Notification Alert - Warning 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-notify slds-notify--alert slds-theme--warning slds-theme--alert-texture"
+      className="slds-notify slds-notify_alert slds-theme_warning slds-theme_alert-texture"
       role="alert"
     >
       <button
-        className="slds-notify__close slds-button slds-button--icon-inverse"
+        className="slds-notify__close slds-button slds-button_icon-inverse"
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="slds-button__icon slds-button__icon--small slds-button__icon--inverse"
+          className="slds-button__icon slds-button__icon_small slds-button__icon_inverse"
           pointerEvents="none"
         >
           <use
@@ -48436,7 +46724,7 @@ exports[`Storyshots Notification Alert - Warning 1`] = `
       <h2>
         <svg
           aria-hidden={true}
-          className="slds-icon slds-icon--small slds-icon-text-default slds-m-right--x-small"
+          className="slds-icon slds-icon_small slds-icon-text-default slds-m-right_x-small"
         >
           <use
             xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#warning"
@@ -48482,17 +46770,17 @@ exports[`Storyshots Notification Controlled with knobs 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-notify slds-notify--alert slds-theme--alert-texture"
+      className="slds-notify slds-notify_alert slds-theme_alert-texture"
       role="alert"
     >
       <button
-        className="slds-notify__close slds-button slds-button--icon-inverse"
+        className="slds-notify__close slds-button slds-button_icon-inverse"
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="slds-button__icon slds-button__icon--small slds-button__icon--inverse"
+          className="slds-button__icon slds-button__icon_small slds-button__icon_inverse"
           pointerEvents="none"
         >
           <use
@@ -48542,7 +46830,7 @@ exports[`Storyshots Notification Toast - Default 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-notify slds-notify--toast slds-theme--alert-texture"
+      className="slds-notify slds-notify_toast slds-theme_alert-texture"
       role="alert"
     >
       <div
@@ -48552,7 +46840,7 @@ exports[`Storyshots Notification Toast - Default 1`] = `
           className="slds-col slds-align-middle"
         >
           <h2
-            className="slds-text-heading--small"
+            className="slds-text-heading_small"
           >
             This is default toast without close.
           </h2>
@@ -48592,17 +46880,17 @@ exports[`Storyshots Notification Toast - Error 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-notify slds-notify--toast slds-theme--error"
+      className="slds-notify slds-notify_toast slds-theme_error"
       role="alert"
     >
       <button
-        className="slds-notify__close slds-button slds-button--icon-inverse"
+        className="slds-notify__close slds-button slds-button_icon-inverse"
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="slds-button__icon slds-button__icon--large slds-button__icon--inverse"
+          className="slds-button__icon slds-button__icon_large slds-button__icon_inverse"
           pointerEvents="none"
         >
           <use
@@ -48620,7 +46908,7 @@ exports[`Storyshots Notification Toast - Error 1`] = `
       >
         <svg
           aria-hidden={true}
-          className="slds-icon slds-icon--small slds-m-right--small"
+          className="slds-icon slds-icon_small slds-m-right_small"
         >
           <use
             xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#warning"
@@ -48630,7 +46918,7 @@ exports[`Storyshots Notification Toast - Error 1`] = `
           className="slds-col slds-align-middle"
         >
           <h2
-            className="slds-text-heading--small"
+            className="slds-text-heading_small"
           >
             This is 
             <strong>
@@ -48674,17 +46962,17 @@ exports[`Storyshots Notification Toast - Info 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-notify slds-notify--toast slds-theme--info slds-theme--alert-texture"
+      className="slds-notify slds-notify_toast slds-theme_info slds-theme_alert-texture"
       role="alert"
     >
       <button
-        className="slds-notify__close slds-button slds-button--icon-inverse"
+        className="slds-notify__close slds-button slds-button_icon-inverse"
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="slds-button__icon slds-button__icon--large slds-button__icon--inverse"
+          className="slds-button__icon slds-button__icon_large slds-button__icon_inverse"
           pointerEvents="none"
         >
           <use
@@ -48702,7 +46990,7 @@ exports[`Storyshots Notification Toast - Info 1`] = `
       >
         <svg
           aria-hidden={true}
-          className="slds-icon slds-icon--small slds-m-right--small"
+          className="slds-icon slds-icon_small slds-m-right_small"
         >
           <use
             xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#info"
@@ -48712,7 +47000,7 @@ exports[`Storyshots Notification Toast - Info 1`] = `
           className="slds-col slds-align-middle"
         >
           <h2
-            className="slds-text-heading--small"
+            className="slds-text-heading_small"
           >
             This is 
             <strong>
@@ -48756,17 +47044,17 @@ exports[`Storyshots Notification Toast - Success 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-notify slds-notify--toast slds-theme--success slds-theme--alert-texture"
+      className="slds-notify slds-notify_toast slds-theme_success slds-theme_alert-texture"
       role="alert"
     >
       <button
-        className="slds-notify__close slds-button slds-button--icon-inverse"
+        className="slds-notify__close slds-button slds-button_icon-inverse"
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="slds-button__icon slds-button__icon--large slds-button__icon--inverse"
+          className="slds-button__icon slds-button__icon_large slds-button__icon_inverse"
           pointerEvents="none"
         >
           <use
@@ -48784,7 +47072,7 @@ exports[`Storyshots Notification Toast - Success 1`] = `
       >
         <svg
           aria-hidden={true}
-          className="slds-icon slds-icon--small slds-m-right--small"
+          className="slds-icon slds-icon_small slds-m-right_small"
         >
           <use
             xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#notification"
@@ -48794,7 +47082,7 @@ exports[`Storyshots Notification Toast - Success 1`] = `
           className="slds-col slds-align-middle"
         >
           <h2
-            className="slds-text-heading--small"
+            className="slds-text-heading_small"
           >
             This is 
             <strong>
@@ -48838,17 +47126,17 @@ exports[`Storyshots Notification Toast - Warning 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-notify slds-notify--toast slds-theme--warning"
+      className="slds-notify slds-notify_toast slds-theme_warning"
       role="alert"
     >
       <button
-        className="slds-notify__close slds-button slds-button--icon-inverse"
+        className="slds-notify__close slds-button slds-button_icon-inverse"
         onClick={[Function]}
         type="button"
       >
         <svg
           aria-hidden={true}
-          className="slds-button__icon slds-button__icon--large slds-button__icon--inverse"
+          className="slds-button__icon slds-button__icon_large slds-button__icon_inverse"
           pointerEvents="none"
         >
           <use
@@ -48866,7 +47154,7 @@ exports[`Storyshots Notification Toast - Warning 1`] = `
       >
         <svg
           aria-hidden={true}
-          className="slds-icon slds-icon--small slds-icon-text-default slds-m-right--small"
+          className="slds-icon slds-icon_small slds-icon-text-default slds-m-right_small"
         >
           <use
             xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#warning"
@@ -48876,7 +47164,7 @@ exports[`Storyshots Notification Toast - Warning 1`] = `
           className="slds-col slds-align-middle"
         >
           <h2
-            className="slds-text-heading--small"
+            className="slds-text-heading_small"
           >
             This is 
             <strong>
@@ -48944,12 +47232,12 @@ exports[`Storyshots PageHeader Base 1`] = `
           >
             <div>
               <h1
-                className="slds-m-right--small slds-page-header__title slds-truncate slds-align-middle"
+                className="slds-m-right_small slds-page-header__title slds-truncate slds-align-middle"
               >
                 Rohde Corp - 80,000 Widgets
               </h1>
               <p
-                className="slds-text-body--small"
+                className="slds-text-body_small"
               >
                 Mark Jaeckal • Unlimited Customer • 11/13/15
               </p>
@@ -49003,7 +47291,7 @@ exports[`Storyshots PageHeader Object Home 1`] = `
           >
             <div>
               <p
-                className="slds-text-title--caps slds-line-height--reset"
+                className="slds-text-title_caps slds-line-height_reset"
               >
                 LEADS
               </p>
@@ -49023,7 +47311,7 @@ exports[`Storyshots PageHeader Object Home 1`] = `
                   >
                     <button
                       aria-haspopup={true}
-                      className="slds-button slds-button--icon-bare"
+                      className="slds-button slds-button_icon-bare"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
@@ -49045,11 +47333,11 @@ exports[`Storyshots PageHeader Object Home 1`] = `
                   className="slds-shrink-none slds-col"
                 >
                   <div
-                    className="slds-m-left--large slds-dropdown-trigger slds-button-space-left"
+                    className="slds-m-left_large slds-dropdown-trigger slds-button-space-left"
                   >
                     <button
                       aria-haspopup={true}
-                      className="slds-button slds-button--icon-more"
+                      className="slds-button slds-button_icon-more"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
@@ -49066,7 +47354,7 @@ exports[`Storyshots PageHeader Object Home 1`] = `
                       </svg>
                       <svg
                         aria-hidden={true}
-                        className="slds-button__icon slds-button__icon--right slds-button__icon--x-small"
+                        className="slds-button__icon slds-button__icon_right slds-button__icon_x-small"
                         pointerEvents="none"
                       >
                         <use
@@ -49083,7 +47371,7 @@ exports[`Storyshots PageHeader Object Home 1`] = `
             className="slds-col slds-align-top slds-no-flex"
           >
             <div
-              className="slds-grid slds-grid--vertical"
+              className="slds-grid slds-grid_vertical"
             >
               <div
                 className="slds-grid slds-wrap"
@@ -49096,7 +47384,7 @@ exports[`Storyshots PageHeader Object Home 1`] = `
                   >
                     <button
                       aria-haspopup={true}
-                      className="slds-button slds-button--icon-more"
+                      className="slds-button slds-button_icon-more"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
@@ -49113,7 +47401,7 @@ exports[`Storyshots PageHeader Object Home 1`] = `
                       </svg>
                       <svg
                         aria-hidden={true}
-                        className="slds-button__icon slds-button__icon--right slds-button__icon--x-small"
+                        className="slds-button__icon slds-button__icon_right slds-button__icon_x-small"
                         pointerEvents="none"
                       >
                         <use
@@ -49131,7 +47419,7 @@ exports[`Storyshots PageHeader Object Home 1`] = `
                     role="group"
                   >
                     <button
-                      className="slds-button slds-button--icon-border"
+                      className="slds-button slds-button_icon-border"
                       onClick={[Function]}
                       type="button"
                     >
@@ -49146,7 +47434,7 @@ exports[`Storyshots PageHeader Object Home 1`] = `
                       </svg>
                     </button>
                     <button
-                      className="slds-button slds-button--icon-border"
+                      className="slds-button slds-button_icon-border"
                       onClick={[Function]}
                       type="button"
                     >
@@ -49177,7 +47465,7 @@ exports[`Storyshots PageHeader Object Home 1`] = `
                         />
                         <button
                           aria-haspopup={true}
-                          className="slds-button slds-button--icon-more"
+                          className="slds-button slds-button_icon-more"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onKeyDown={[Function]}
@@ -49194,7 +47482,7 @@ exports[`Storyshots PageHeader Object Home 1`] = `
                           </svg>
                           <svg
                             aria-hidden={true}
-                            className="slds-button__icon slds-button__icon--right slds-button__icon--x-small"
+                            className="slds-button__icon slds-button__icon_right slds-button__icon_x-small"
                             pointerEvents="none"
                           >
                             <use
@@ -49214,7 +47502,7 @@ exports[`Storyshots PageHeader Object Home 1`] = `
                     role="group"
                   >
                     <button
-                      className="slds-button slds-button--neutral"
+                      className="slds-button slds-button_neutral"
                       onClick={[Function]}
                       type="button"
                     >
@@ -49237,7 +47525,7 @@ exports[`Storyshots PageHeader Object Home 1`] = `
                         />
                         <button
                           aria-haspopup={true}
-                          className="slds-button slds-button--icon-border-filled"
+                          className="slds-button slds-button_icon-border-filled"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onKeyDown={[Function]}
@@ -49262,7 +47550,7 @@ exports[`Storyshots PageHeader Object Home 1`] = `
           </div>
         </div>
         <p
-          className="slds-text-body--small"
+          className="slds-text-body_small"
         >
           10 items • Sorted by Name
         </p>
@@ -49319,7 +47607,7 @@ exports[`Storyshots PageHeader Record Home 1`] = `
               >
                 <svg
                   aria-hidden={true}
-                  className="slds-icon slds-icon--large slds-icon-standard-user"
+                  className="slds-icon slds-icon_large slds-icon-standard-user"
                 >
                   <use
                     xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#user"
@@ -49331,7 +47619,7 @@ exports[`Storyshots PageHeader Record Home 1`] = `
               >
                 <div>
                   <p
-                    className="slds-text-title--caps slds-line-height--reset"
+                    className="slds-text-title_caps slds-line-height_reset"
                   >
                     RECORD TYPE
                   </p>
@@ -49339,7 +47627,7 @@ exports[`Storyshots PageHeader Record Home 1`] = `
                     className="slds-grid"
                   >
                     <h1
-                      className="slds-m-right--small slds-page-header__title slds-truncate slds-align-middle"
+                      className="slds-m-right_small slds-page-header__title slds-truncate slds-align-middle"
                     >
                       Record Title
                     </h1>
@@ -49347,13 +47635,13 @@ exports[`Storyshots PageHeader Record Home 1`] = `
                       className="slds-shrink-none slds-col"
                     >
                       <button
-                        className="slds-button slds-button--neutral"
+                        className="slds-button slds-button_neutral"
                         onClick={[Function]}
                         type="button"
                       >
                         <svg
                           aria-hidden={true}
-                          className="slds-button__icon slds-button__icon--left"
+                          className="slds-button__icon slds-button__icon_left"
                           pointerEvents="none"
                         >
                           <use
@@ -49372,7 +47660,7 @@ exports[`Storyshots PageHeader Record Home 1`] = `
             className="slds-col slds-align-top slds-no-flex"
           >
             <div
-              className="slds-grid slds-grid--vertical"
+              className="slds-grid slds-grid_vertical"
             >
               <div
                 className="slds-grid slds-wrap"
@@ -49385,21 +47673,21 @@ exports[`Storyshots PageHeader Record Home 1`] = `
                     role="group"
                   >
                     <button
-                      className="slds-button slds-button--neutral"
+                      className="slds-button slds-button_neutral"
                       onClick={[Function]}
                       type="button"
                     >
                       Edit
                     </button>
                     <button
-                      className="slds-button slds-button--neutral"
+                      className="slds-button slds-button_neutral"
                       onClick={[Function]}
                       type="button"
                     >
                       Delete
                     </button>
                     <button
-                      className="slds-button slds-button--neutral"
+                      className="slds-button slds-button_neutral"
                       onClick={[Function]}
                       type="button"
                     >
@@ -49422,7 +47710,7 @@ exports[`Storyshots PageHeader Record Home 1`] = `
                         />
                         <button
                           aria-haspopup={true}
-                          className="slds-button slds-button--icon-border"
+                          className="slds-button slds-button_icon-border"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onKeyDown={[Function]}
@@ -49454,12 +47742,12 @@ exports[`Storyshots PageHeader Record Home 1`] = `
           className="slds-page-header__detail-block"
         >
           <p
-            className="slds-text-title slds-truncate slds-m-bottom--xx-small"
+            className="slds-text-title slds-truncate slds-m-bottom_xx-small"
           >
             FIELD 1
           </p>
           <p
-            className="slds-text-body--regular slds-truncate"
+            className="slds-text-body_regular slds-truncate"
             title="Description that demonstrates truncation with a long text field"
           >
             Description that demonstrates truncation with a long text field
@@ -49469,7 +47757,7 @@ exports[`Storyshots PageHeader Record Home 1`] = `
           className="slds-page-header__detail-block"
         >
           <div
-            className="slds-text-heading--label"
+            className="slds-text-heading_label"
           >
             FIELD 2 (3)
             <div
@@ -49477,7 +47765,7 @@ exports[`Storyshots PageHeader Record Home 1`] = `
             >
               <button
                 aria-haspopup={true}
-                className="slds-button slds-button--icon-bare"
+                className="slds-button slds-button_icon-bare"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -49485,7 +47773,7 @@ exports[`Storyshots PageHeader Record Home 1`] = `
               >
                 <svg
                   aria-hidden={true}
-                  className="slds-button__icon slds-button__icon--small"
+                  className="slds-button__icon slds-button__icon_small"
                   pointerEvents="none"
                 >
                   <use
@@ -49496,7 +47784,7 @@ exports[`Storyshots PageHeader Record Home 1`] = `
             </div>
           </div>
           <p
-            className="slds-text-body--regular"
+            className="slds-text-body_regular"
             title="Multiple Values"
           >
             Multiple Values
@@ -49506,7 +47794,7 @@ exports[`Storyshots PageHeader Record Home 1`] = `
           className="slds-page-header__detail-block"
         >
           <p
-            className="slds-text-title slds-truncate slds-m-bottom--xx-small"
+            className="slds-text-title slds-truncate slds-m-bottom_xx-small"
           >
             FIELD 3
           </p>
@@ -49518,7 +47806,7 @@ exports[`Storyshots PageHeader Record Home 1`] = `
           className="slds-page-header__detail-block"
         >
           <p
-            className="slds-text-title slds-truncate slds-m-bottom--xx-small"
+            className="slds-text-title slds-truncate slds-m-bottom_xx-small"
           >
             FIELD 4
           </p>
@@ -49577,10 +47865,10 @@ exports[`Storyshots PageHeader Related List 1`] = `
               >
                 <ol
                   aria-labelledby="bread-crumb-label"
-                  className="slds-breadcrumb slds-list--horizontal"
+                  className="slds-breadcrumb slds-list_horizontal"
                 >
                   <li
-                    className="slds-list__item slds-text-heading--label"
+                    className="slds-list__item slds-text-heading_label"
                   >
                     <a
                       href="#"
@@ -49589,7 +47877,7 @@ exports[`Storyshots PageHeader Related List 1`] = `
                     </a>
                   </li>
                   <li
-                    className="slds-list__item slds-text-heading--label"
+                    className="slds-list__item slds-text-heading_label"
                   >
                     <a
                       href="#"
@@ -49600,7 +47888,7 @@ exports[`Storyshots PageHeader Related List 1`] = `
                 </ol>
               </nav>
               <h1
-                className="slds-m-right--small slds-page-header__title slds-truncate slds-align-middle"
+                className="slds-m-right_small slds-page-header__title slds-truncate slds-align-middle"
               >
                 Contacts (will truncate)
               </h1>
@@ -49610,7 +47898,7 @@ exports[`Storyshots PageHeader Related List 1`] = `
             className="slds-col slds-align-top slds-no-flex"
           >
             <div
-              className="slds-grid slds-grid--vertical"
+              className="slds-grid slds-grid_vertical"
             >
               <div
                 className="slds-grid slds-wrap"
@@ -49623,7 +47911,7 @@ exports[`Storyshots PageHeader Related List 1`] = `
                   >
                     <button
                       aria-haspopup={true}
-                      className="slds-button slds-button--icon-more"
+                      className="slds-button slds-button_icon-more"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}
@@ -49640,7 +47928,7 @@ exports[`Storyshots PageHeader Related List 1`] = `
                       </svg>
                       <svg
                         aria-hidden={true}
-                        className="slds-button__icon slds-button__icon--right slds-button__icon--x-small"
+                        className="slds-button__icon slds-button__icon_right slds-button__icon_x-small"
                         pointerEvents="none"
                       >
                         <use
@@ -49658,7 +47946,7 @@ exports[`Storyshots PageHeader Related List 1`] = `
                     role="group"
                   >
                     <button
-                      className="slds-button slds-button--icon-border"
+                      className="slds-button slds-button_icon-border"
                       onClick={[Function]}
                       type="button"
                     >
@@ -49673,7 +47961,7 @@ exports[`Storyshots PageHeader Related List 1`] = `
                       </svg>
                     </button>
                     <button
-                      className="slds-button slds-button--icon-border"
+                      className="slds-button slds-button_icon-border"
                       onClick={[Function]}
                       type="button"
                     >
@@ -49704,7 +47992,7 @@ exports[`Storyshots PageHeader Related List 1`] = `
                         />
                         <button
                           aria-haspopup={true}
-                          className="slds-button slds-button--icon-more"
+                          className="slds-button slds-button_icon-more"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onKeyDown={[Function]}
@@ -49721,7 +48009,7 @@ exports[`Storyshots PageHeader Related List 1`] = `
                           </svg>
                           <svg
                             aria-hidden={true}
-                            className="slds-button__icon slds-button__icon--right slds-button__icon--x-small"
+                            className="slds-button__icon slds-button__icon_right slds-button__icon_x-small"
                             pointerEvents="none"
                           >
                             <use
@@ -49741,7 +48029,7 @@ exports[`Storyshots PageHeader Related List 1`] = `
                     role="group"
                   >
                     <button
-                      className="slds-button slds-button--neutral"
+                      className="slds-button slds-button_neutral"
                       onClick={[Function]}
                       type="button"
                     >
@@ -49764,7 +48052,7 @@ exports[`Storyshots PageHeader Related List 1`] = `
                         />
                         <button
                           aria-haspopup={true}
-                          className="slds-button slds-button--icon-border-filled"
+                          className="slds-button slds-button_icon-border-filled"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onKeyDown={[Function]}
@@ -49789,7 +48077,7 @@ exports[`Storyshots PageHeader Related List 1`] = `
           </div>
         </div>
         <p
-          className="slds-text-body--small"
+          className="slds-text-body_small"
         >
           10 items, sorted by name
         </p>
@@ -49843,7 +48131,7 @@ exports[`Storyshots Picklist Controlled with knobs 1`] = `
           className="slds-picklist slds-dropdown-trigger"
         >
           <button
-            className="slds-picklist__label slds-button slds-button--neutral"
+            className="slds-picklist__label slds-button slds-button_neutral"
             disabled={false}
             id="form-element-$uuid$"
             onBlur={[Function]}
@@ -49926,7 +48214,7 @@ exports[`Storyshots Picklist Default 1`] = `
           className="slds-picklist slds-dropdown-trigger"
         >
           <button
-            className="slds-picklist__label slds-button slds-button--neutral"
+            className="slds-picklist__label slds-button slds-button_neutral"
             id="form-element-$uuid$"
             onBlur={[Function]}
             onChange={[Function]}
@@ -49954,7 +48242,7 @@ exports[`Storyshots Picklist Default 1`] = `
             </svg>
           </button>
           <div
-            className="slds-dropdown slds-dropdown--top slds-dropdown--left react-slds-no-hover-popup"
+            className="slds-dropdown slds-dropdown_top slds-dropdown_left react-slds-no-hover-popup"
             onBlur={[Function]}
             onKeyDown={[Function]}
             style={
@@ -49985,7 +48273,7 @@ exports[`Storyshots Picklist Default 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50012,7 +48300,7 @@ exports[`Storyshots Picklist Default 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50039,7 +48327,7 @@ exports[`Storyshots Picklist Default 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50102,7 +48390,7 @@ exports[`Storyshots Picklist Disabled 1`] = `
           className="slds-picklist slds-dropdown-trigger"
         >
           <button
-            className="slds-picklist__label slds-button slds-button--neutral"
+            className="slds-picklist__label slds-button slds-button_neutral"
             disabled={true}
             id="form-element-$uuid$"
             onChange={[Function]}
@@ -50183,7 +48471,7 @@ exports[`Storyshots Picklist Disabled Items 1`] = `
           className="slds-picklist slds-dropdown-trigger"
         >
           <button
-            className="slds-picklist__label slds-button slds-button--neutral"
+            className="slds-picklist__label slds-button slds-button_neutral"
             id="form-element-$uuid$"
             onBlur={[Function]}
             onChange={[Function]}
@@ -50213,7 +48501,7 @@ exports[`Storyshots Picklist Disabled Items 1`] = `
             </svg>
           </button>
           <div
-            className="slds-dropdown slds-dropdown--top slds-dropdown--left react-slds-no-hover-popup"
+            className="slds-dropdown slds-dropdown_top slds-dropdown_left react-slds-no-hover-popup"
             onBlur={[Function]}
             onKeyDown={[Function]}
             style={
@@ -50240,7 +48528,7 @@ exports[`Storyshots Picklist Disabled Items 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50263,7 +48551,7 @@ exports[`Storyshots Picklist Disabled Items 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50286,7 +48574,7 @@ exports[`Storyshots Picklist Disabled Items 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50353,7 +48641,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
             className="slds-picklist slds-dropdown-trigger"
           >
             <button
-              className="slds-picklist__label slds-button slds-button--neutral"
+              className="slds-picklist__label slds-button slds-button_neutral"
               id="form-element-$uuid$"
               onBlur={[Function]}
               onChange={[Function]}
@@ -50381,7 +48669,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
               </svg>
             </button>
             <div
-              className="slds-dropdown slds-dropdown--top slds-dropdown--left slds-dropdown--small react-slds-no-hover-popup"
+              className="slds-dropdown slds-dropdown_top slds-dropdown_left slds-dropdown_small react-slds-no-hover-popup"
               onBlur={[Function]}
               onKeyDown={[Function]}
               style={
@@ -50414,7 +48702,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50441,7 +48729,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50468,7 +48756,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50495,7 +48783,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50522,7 +48810,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50549,7 +48837,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50576,7 +48864,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50603,7 +48891,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50630,7 +48918,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50657,7 +48945,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50684,7 +48972,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50711,7 +48999,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50738,7 +49026,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50765,7 +49053,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50792,7 +49080,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50819,7 +49107,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50846,7 +49134,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50873,7 +49161,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50900,7 +49188,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50927,7 +49215,7 @@ exports[`Storyshots Picklist Dropdown Scroll 1`] = `
                     >
                       <svg
                         aria-hidden={true}
-                        className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                       >
                         <use
                           xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -50997,7 +49285,7 @@ exports[`Storyshots Picklist Error 1`] = `
           className="slds-picklist slds-dropdown-trigger"
         >
           <button
-            className="slds-picklist__label slds-button slds-button--neutral"
+            className="slds-picklist__label slds-button slds-button_neutral"
             id="form-element-$uuid$"
             onBlur={[Function]}
             onChange={[Function]}
@@ -51027,7 +49315,7 @@ exports[`Storyshots Picklist Error 1`] = `
             </svg>
           </button>
           <div
-            className="slds-dropdown slds-dropdown--top slds-dropdown--left react-slds-no-hover-popup"
+            className="slds-dropdown slds-dropdown_top slds-dropdown_left react-slds-no-hover-popup"
             onBlur={[Function]}
             onKeyDown={[Function]}
             style={
@@ -51058,7 +49346,7 @@ exports[`Storyshots Picklist Error 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -51085,7 +49373,7 @@ exports[`Storyshots Picklist Error 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -51112,7 +49400,7 @@ exports[`Storyshots Picklist Error 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -51181,7 +49469,7 @@ exports[`Storyshots Picklist Menu Size - Large 1`] = `
           className="slds-picklist slds-dropdown-trigger"
         >
           <button
-            className="slds-picklist__label slds-button slds-button--neutral"
+            className="slds-picklist__label slds-button slds-button_neutral"
             id="form-element-$uuid$"
             onBlur={[Function]}
             onChange={[Function]}
@@ -51209,7 +49497,7 @@ exports[`Storyshots Picklist Menu Size - Large 1`] = `
             </svg>
           </button>
           <div
-            className="slds-dropdown slds-dropdown--top slds-dropdown--left slds-dropdown--large react-slds-no-hover-popup"
+            className="slds-dropdown slds-dropdown_top slds-dropdown_left slds-dropdown_large react-slds-no-hover-popup"
             onBlur={[Function]}
             onKeyDown={[Function]}
             style={
@@ -51240,7 +49528,7 @@ exports[`Storyshots Picklist Menu Size - Large 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -51267,7 +49555,7 @@ exports[`Storyshots Picklist Menu Size - Large 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -51294,7 +49582,7 @@ exports[`Storyshots Picklist Menu Size - Large 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -51358,7 +49646,7 @@ exports[`Storyshots Picklist Menu Size - Medium 1`] = `
           className="slds-picklist slds-dropdown-trigger"
         >
           <button
-            className="slds-picklist__label slds-button slds-button--neutral"
+            className="slds-picklist__label slds-button slds-button_neutral"
             id="form-element-$uuid$"
             onBlur={[Function]}
             onChange={[Function]}
@@ -51386,7 +49674,7 @@ exports[`Storyshots Picklist Menu Size - Medium 1`] = `
             </svg>
           </button>
           <div
-            className="slds-dropdown slds-dropdown--top slds-dropdown--left slds-dropdown--medium react-slds-no-hover-popup"
+            className="slds-dropdown slds-dropdown_top slds-dropdown_left slds-dropdown_medium react-slds-no-hover-popup"
             onBlur={[Function]}
             onKeyDown={[Function]}
             style={
@@ -51417,7 +49705,7 @@ exports[`Storyshots Picklist Menu Size - Medium 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -51444,7 +49732,7 @@ exports[`Storyshots Picklist Menu Size - Medium 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -51471,7 +49759,7 @@ exports[`Storyshots Picklist Menu Size - Medium 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -51535,7 +49823,7 @@ exports[`Storyshots Picklist Multiple items selected 1`] = `
           className="slds-picklist slds-dropdown-trigger"
         >
           <button
-            className="slds-picklist__label slds-button slds-button--neutral"
+            className="slds-picklist__label slds-button slds-button_neutral"
             id="form-element-$uuid$"
             onBlur={[Function]}
             onChange={[Function]}
@@ -51563,7 +49851,7 @@ exports[`Storyshots Picklist Multiple items selected 1`] = `
             </svg>
           </button>
           <div
-            className="slds-dropdown slds-dropdown--top slds-dropdown--left react-slds-no-hover-popup"
+            className="slds-dropdown slds-dropdown_top slds-dropdown_left react-slds-no-hover-popup"
             onBlur={[Function]}
             onKeyDown={[Function]}
             style={
@@ -51594,7 +49882,7 @@ exports[`Storyshots Picklist Multiple items selected 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#check"
@@ -51621,7 +49909,7 @@ exports[`Storyshots Picklist Multiple items selected 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -51648,7 +49936,7 @@ exports[`Storyshots Picklist Multiple items selected 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#check"
@@ -51717,7 +50005,7 @@ exports[`Storyshots Picklist Required 1`] = `
           className="slds-picklist slds-dropdown-trigger"
         >
           <button
-            className="slds-picklist__label slds-button slds-button--neutral"
+            className="slds-picklist__label slds-button slds-button_neutral"
             id="form-element-$uuid$"
             onBlur={[Function]}
             onChange={[Function]}
@@ -51747,7 +50035,7 @@ exports[`Storyshots Picklist Required 1`] = `
             </svg>
           </button>
           <div
-            className="slds-dropdown slds-dropdown--top slds-dropdown--left react-slds-no-hover-popup"
+            className="slds-dropdown slds-dropdown_top slds-dropdown_left react-slds-no-hover-popup"
             onBlur={[Function]}
             onKeyDown={[Function]}
             style={
@@ -51778,7 +50066,7 @@ exports[`Storyshots Picklist Required 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -51805,7 +50093,7 @@ exports[`Storyshots Picklist Required 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -51832,7 +50120,7 @@ exports[`Storyshots Picklist Required 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -51896,7 +50184,7 @@ exports[`Storyshots Picklist Single item selected 1`] = `
           className="slds-picklist slds-dropdown-trigger"
         >
           <button
-            className="slds-picklist__label slds-button slds-button--neutral"
+            className="slds-picklist__label slds-button slds-button_neutral"
             id="form-element-$uuid$"
             onBlur={[Function]}
             onChange={[Function]}
@@ -51924,7 +50212,7 @@ exports[`Storyshots Picklist Single item selected 1`] = `
             </svg>
           </button>
           <div
-            className="slds-dropdown slds-dropdown--top slds-dropdown--left react-slds-no-hover-popup"
+            className="slds-dropdown slds-dropdown_top slds-dropdown_left react-slds-no-hover-popup"
             onBlur={[Function]}
             onKeyDown={[Function]}
             style={
@@ -51955,7 +50243,7 @@ exports[`Storyshots Picklist Single item selected 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#check"
@@ -51982,7 +50270,7 @@ exports[`Storyshots Picklist Single item selected 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -52009,7 +50297,7 @@ exports[`Storyshots Picklist Single item selected 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-m-right--x-small"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-m-right_x-small"
                     >
                       <use
                         xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#none"
@@ -52067,7 +50355,7 @@ exports[`Storyshots Pill Controlled with knobs 1`] = `
         Pill Label
       </span>
       <button
-        className="slds-pill__remove slds-button slds-button--icon-bare"
+        className="slds-pill__remove slds-button slds-button_icon-bare"
         disabled={false}
         onClick={[Function]}
         tabIndex={-1}
@@ -52132,7 +50420,7 @@ exports[`Storyshots Pill disabled 1`] = `
         Pill Label
       </span>
       <button
-        className="slds-pill__remove slds-button slds-button--icon-bare"
+        className="slds-pill__remove slds-button slds-button_icon-bare"
         disabled={true}
         onClick={[Function]}
         tabIndex={-1}
@@ -52207,7 +50495,7 @@ exports[`Storyshots Pill truncate 1`] = `
             Pill Label that is longer than the area that contains it
           </span>
           <button
-            className="slds-pill__remove slds-button slds-button--icon-bare"
+            className="slds-pill__remove slds-button slds-button_icon-bare"
             onClick={[Function]}
             tabIndex={-1}
             type="button"
@@ -52281,7 +50569,7 @@ exports[`Storyshots Pill with icon 1`] = `
         Pill Label
       </span>
       <button
-        className="slds-pill__remove slds-button slds-button--icon-bare"
+        className="slds-pill__remove slds-button slds-button_icon-bare"
         onClick={[Function]}
         tabIndex={-1}
         type="button"
@@ -52345,7 +50633,7 @@ exports[`Storyshots Popover Controlled with knobs 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -52360,7 +50648,7 @@ exports[`Storyshots Popover Controlled with knobs 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-nubbin--top-left slds-m-top--small"
+          className="slds-popover slds-nubbin_top-left slds-m-top_small"
           role="dialog"
           style={
             Object {
@@ -52427,7 +50715,7 @@ exports[`Storyshots Popover Default 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -52442,7 +50730,7 @@ exports[`Storyshots Popover Default 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-nubbin--left slds-m-left--small"
+          className="slds-popover slds-nubbin_left slds-m-left_small"
           role="dialog"
           style={
             Object {
@@ -52508,7 +50796,7 @@ exports[`Storyshots Popover Position - Bottom (left) 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -52523,7 +50811,7 @@ exports[`Storyshots Popover Position - Bottom (left) 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-nubbin--bottom-left slds-m-bottom--small"
+          className="slds-popover slds-nubbin_bottom-left slds-m-bottom_small"
           role="dialog"
           style={
             Object {
@@ -52590,7 +50878,7 @@ exports[`Storyshots Popover Position - Bottom (right) 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -52605,7 +50893,7 @@ exports[`Storyshots Popover Position - Bottom (right) 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-nubbin--bottom-right slds-m-bottom--small"
+          className="slds-popover slds-nubbin_bottom-right slds-m-bottom_small"
           role="dialog"
           style={
             Object {
@@ -52672,7 +50960,7 @@ exports[`Storyshots Popover Position - Bottom 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -52687,7 +50975,7 @@ exports[`Storyshots Popover Position - Bottom 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-nubbin--bottom slds-m-bottom--small"
+          className="slds-popover slds-nubbin_bottom slds-m-bottom_small"
           role="dialog"
           style={
             Object {
@@ -52753,7 +51041,7 @@ exports[`Storyshots Popover Position - Left (bottom) 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -52768,7 +51056,7 @@ exports[`Storyshots Popover Position - Left (bottom) 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-nubbin--left-bottom slds-m-left--small"
+          className="slds-popover slds-nubbin_left-bottom slds-m-left_small"
           role="dialog"
           style={
             Object {
@@ -52835,7 +51123,7 @@ exports[`Storyshots Popover Position - Left (top) 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -52850,7 +51138,7 @@ exports[`Storyshots Popover Position - Left (top) 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-nubbin--left-top slds-m-left--small"
+          className="slds-popover slds-nubbin_left-top slds-m-left_small"
           role="dialog"
           style={
             Object {
@@ -52917,7 +51205,7 @@ exports[`Storyshots Popover Position - Left 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -52932,7 +51220,7 @@ exports[`Storyshots Popover Position - Left 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-nubbin--left slds-m-left--small"
+          className="slds-popover slds-nubbin_left slds-m-left_small"
           role="dialog"
           style={
             Object {
@@ -52998,7 +51286,7 @@ exports[`Storyshots Popover Position - Right (bottom) 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -53013,7 +51301,7 @@ exports[`Storyshots Popover Position - Right (bottom) 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-nubbin--right-bottom slds-m-right--small"
+          className="slds-popover slds-nubbin_right-bottom slds-m-right_small"
           role="dialog"
           style={
             Object {
@@ -53080,7 +51368,7 @@ exports[`Storyshots Popover Position - Right (top) 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -53095,7 +51383,7 @@ exports[`Storyshots Popover Position - Right (top) 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-nubbin--right-top slds-m-right--small"
+          className="slds-popover slds-nubbin_right-top slds-m-right_small"
           role="dialog"
           style={
             Object {
@@ -53162,7 +51450,7 @@ exports[`Storyshots Popover Position - Right 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -53177,7 +51465,7 @@ exports[`Storyshots Popover Position - Right 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-nubbin--right slds-m-right--small"
+          className="slds-popover slds-nubbin_right slds-m-right_small"
           role="dialog"
           style={
             Object {
@@ -53243,7 +51531,7 @@ exports[`Storyshots Popover Position - Top (left) 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -53258,7 +51546,7 @@ exports[`Storyshots Popover Position - Top (left) 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-nubbin--top-left slds-m-top--small"
+          className="slds-popover slds-nubbin_top-left slds-m-top_small"
           role="dialog"
           style={
             Object {
@@ -53325,7 +51613,7 @@ exports[`Storyshots Popover Position - Top (right) 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -53340,7 +51628,7 @@ exports[`Storyshots Popover Position - Top (right) 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-nubbin--top-right slds-m-top--small"
+          className="slds-popover slds-nubbin_top-right slds-m-top_small"
           role="dialog"
           style={
             Object {
@@ -53407,7 +51695,7 @@ exports[`Storyshots Popover Position - Top 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -53422,7 +51710,7 @@ exports[`Storyshots Popover Position - Top 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-nubbin--top slds-m-top--small"
+          className="slds-popover slds-nubbin_top slds-m-top_small"
           role="dialog"
           style={
             Object {
@@ -53488,7 +51776,7 @@ exports[`Storyshots Popover Theme - Error 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -53503,7 +51791,7 @@ exports[`Storyshots Popover Theme - Error 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-nubbin--left slds-m-left--small slds-theme--error"
+          className="slds-popover slds-nubbin_left slds-m-left_small slds-theme_error"
           role="dialog"
           style={
             Object {
@@ -53569,7 +51857,7 @@ exports[`Storyshots Popover Theme - Info 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -53584,7 +51872,7 @@ exports[`Storyshots Popover Theme - Info 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-nubbin--left slds-m-left--small slds-theme--info"
+          className="slds-popover slds-nubbin_left slds-m-left_small slds-theme_info"
           role="dialog"
           style={
             Object {
@@ -53650,7 +51938,7 @@ exports[`Storyshots Popover Theme - Success 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -53665,7 +51953,7 @@ exports[`Storyshots Popover Theme - Success 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-nubbin--left slds-m-left--small slds-theme--success"
+          className="slds-popover slds-nubbin_left slds-m-left_small slds-theme_success"
           role="dialog"
           style={
             Object {
@@ -53731,7 +52019,7 @@ exports[`Storyshots Popover Theme - Warning 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -53746,7 +52034,7 @@ exports[`Storyshots Popover Theme - Warning 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-nubbin--left slds-m-left--small slds-theme--warning"
+          className="slds-popover slds-nubbin_left slds-m-left_small slds-theme_warning"
           role="dialog"
           style={
             Object {
@@ -53812,7 +52100,7 @@ exports[`Storyshots Popover Tooltip 1`] = `
         className="slds-dropdown-trigger"
       >
         <button
-          className="slds-button slds-button--icon"
+          className="slds-button slds-button_icon"
           onClick={[Function]}
           type="button"
         >
@@ -53827,7 +52115,7 @@ exports[`Storyshots Popover Tooltip 1`] = `
           </svg>
         </button>
         <div
-          className="slds-popover slds-popover--tooltip slds-nubbin--bottom-left slds-m-bottom--small"
+          className="slds-popover slds-popover_tooltip slds-nubbin_bottom-left slds-m-bottom_small"
           role="tooltip"
           style={
             Object {
@@ -54029,7 +52317,7 @@ exports[`Storyshots Radio Controlled with knobs 1`] = `
       className="slds-form-element"
     >
       <legend
-        className="slds-form-element__label slds-form-element__label--top"
+        className="slds-form-element__label"
       >
         Radio Group Label
       </legend>
@@ -54046,7 +52334,7 @@ exports[`Storyshots Radio Controlled with knobs 1`] = `
             value="1"
           />
           <span
-            className="slds-radio--faux"
+            className="slds-radio_faux"
           />
           <span
             className="slds-form-element__label"
@@ -54064,7 +52352,7 @@ exports[`Storyshots Radio Controlled with knobs 1`] = `
             value="2"
           />
           <span
-            className="slds-radio--faux"
+            className="slds-radio_faux"
           />
           <span
             className="slds-form-element__label"
@@ -54110,7 +52398,7 @@ exports[`Storyshots Radio Default 1`] = `
       className="slds-form-element"
     >
       <legend
-        className="slds-form-element__label slds-form-element__label--top"
+        className="slds-form-element__label"
       >
         Radio Group Label
       </legend>
@@ -54126,7 +52414,7 @@ exports[`Storyshots Radio Default 1`] = `
             value="1"
           />
           <span
-            className="slds-radio--faux"
+            className="slds-radio_faux"
           />
           <span
             className="slds-form-element__label"
@@ -54142,7 +52430,7 @@ exports[`Storyshots Radio Default 1`] = `
             value="2"
           />
           <span
-            className="slds-radio--faux"
+            className="slds-radio_faux"
           />
           <span
             className="slds-form-element__label"
@@ -54188,7 +52476,7 @@ exports[`Storyshots Radio Disabled 1`] = `
       className="slds-form-element"
     >
       <legend
-        className="slds-form-element__label slds-form-element__label--top"
+        className="slds-form-element__label"
       >
         Radio Group Label
       </legend>
@@ -54204,7 +52492,7 @@ exports[`Storyshots Radio Disabled 1`] = `
             value="1"
           />
           <span
-            className="slds-radio--faux"
+            className="slds-radio_faux"
           />
           <span
             className="slds-form-element__label"
@@ -54221,7 +52509,7 @@ exports[`Storyshots Radio Disabled 1`] = `
             value="2"
           />
           <span
-            className="slds-radio--faux"
+            className="slds-radio_faux"
           />
           <span
             className="slds-form-element__label"
@@ -54267,7 +52555,7 @@ exports[`Storyshots Radio Error 1`] = `
       className="slds-form-element slds-has-error slds-is-required"
     >
       <legend
-        className="slds-form-element__label slds-form-element__label--top"
+        className="slds-form-element__label"
       >
         Radio Group Label
         <abbr
@@ -54288,7 +52576,7 @@ exports[`Storyshots Radio Error 1`] = `
             value="1"
           />
           <span
-            className="slds-radio--faux"
+            className="slds-radio_faux"
           />
           <span
             className="slds-form-element__label"
@@ -54304,7 +52592,7 @@ exports[`Storyshots Radio Error 1`] = `
             value="2"
           />
           <span
-            className="slds-radio--faux"
+            className="slds-radio_faux"
           />
           <span
             className="slds-form-element__label"
@@ -54355,7 +52643,7 @@ exports[`Storyshots Radio Required 1`] = `
       className="slds-form-element slds-is-required"
     >
       <legend
-        className="slds-form-element__label slds-form-element__label--top"
+        className="slds-form-element__label"
       >
         Radio Group Label
         <abbr
@@ -54376,7 +52664,7 @@ exports[`Storyshots Radio Required 1`] = `
             value="1"
           />
           <span
-            className="slds-radio--faux"
+            className="slds-radio_faux"
           />
           <span
             className="slds-form-element__label"
@@ -54392,7 +52680,7 @@ exports[`Storyshots Radio Required 1`] = `
             value="2"
           />
           <span
-            className="slds-radio--faux"
+            className="slds-radio_faux"
           />
           <span
             className="slds-form-element__label"
@@ -54435,31 +52723,31 @@ exports[`Storyshots SalesPath Controlled with knobs 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-tabs--path"
+      className="slds-tabs_path"
       role="application tablist"
     >
       <ul
-        className="slds-tabs--path__nav"
+        className="slds-tabs_path__nav"
         role="presentation"
       >
         <li
-          className="slds-tabs--path__item slds-is-current"
+          className="slds-tabs_path__item slds-is-current"
           role="presentation"
         >
           <a
             aria-live="assertive"
             aria-selected="false"
-            className="slds-tabs--path__link"
+            className="slds-tabs_path__link"
             onClick={[Function]}
             role="tab"
             tabIndex={0}
           >
             <span
-              className="slds-tabs--path__stage"
+              className="slds-tabs_path__stage"
             >
               <svg
                 aria-hidden={true}
-                className="slds-icon slds-icon--x-small slds-icon-text-default"
+                className="slds-icon slds-icon_x-small slds-icon-text-default"
               >
                 <use
                   xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#check"
@@ -54467,30 +52755,30 @@ exports[`Storyshots SalesPath Controlled with knobs 1`] = `
               </svg>
             </span>
             <span
-              className="slds-tabs--path__title"
+              className="slds-tabs_path__title"
             >
               Contacted
             </span>
           </a>
         </li>
         <li
-          className="slds-tabs--path__item slds-is-incomplete"
+          className="slds-tabs_path__item slds-is-incomplete"
           role="presentation"
         >
           <a
             aria-live="assertive"
             aria-selected="false"
-            className="slds-tabs--path__link"
+            className="slds-tabs_path__link"
             onClick={[Function]}
             role="tab"
             tabIndex={-1}
           >
             <span
-              className="slds-tabs--path__stage"
+              className="slds-tabs_path__stage"
             >
               <svg
                 aria-hidden={true}
-                className="slds-icon slds-icon--x-small slds-icon-text-default"
+                className="slds-icon slds-icon_x-small slds-icon-text-default"
               >
                 <use
                   xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#check"
@@ -54498,30 +52786,30 @@ exports[`Storyshots SalesPath Controlled with knobs 1`] = `
               </svg>
             </span>
             <span
-              className="slds-tabs--path__title"
+              className="slds-tabs_path__title"
             >
               Open
             </span>
           </a>
         </li>
         <li
-          className="slds-tabs--path__item slds-is-incomplete"
+          className="slds-tabs_path__item slds-is-incomplete"
           role="presentation"
         >
           <a
             aria-live="assertive"
             aria-selected="false"
-            className="slds-tabs--path__link"
+            className="slds-tabs_path__link"
             onClick={[Function]}
             role="tab"
             tabIndex={-1}
           >
             <span
-              className="slds-tabs--path__stage"
+              className="slds-tabs_path__stage"
             >
               <svg
                 aria-hidden={true}
-                className="slds-icon slds-icon--x-small slds-icon-text-default"
+                className="slds-icon slds-icon_x-small slds-icon-text-default"
               >
                 <use
                   xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#check"
@@ -54529,30 +52817,30 @@ exports[`Storyshots SalesPath Controlled with knobs 1`] = `
               </svg>
             </span>
             <span
-              className="slds-tabs--path__title"
+              className="slds-tabs_path__title"
             >
               Unqualified
             </span>
           </a>
         </li>
         <li
-          className="slds-tabs--path__item slds-is-incomplete"
+          className="slds-tabs_path__item slds-is-incomplete"
           role="presentation"
         >
           <a
             aria-live="assertive"
             aria-selected="false"
-            className="slds-tabs--path__link"
+            className="slds-tabs_path__link"
             onClick={[Function]}
             role="tab"
             tabIndex={-1}
           >
             <span
-              className="slds-tabs--path__stage"
+              className="slds-tabs_path__stage"
             >
               <svg
                 aria-hidden={true}
-                className="slds-icon slds-icon--x-small slds-icon-text-default"
+                className="slds-icon slds-icon_x-small slds-icon-text-default"
               >
                 <use
                   xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#check"
@@ -54560,30 +52848,30 @@ exports[`Storyshots SalesPath Controlled with knobs 1`] = `
               </svg>
             </span>
             <span
-              className="slds-tabs--path__title"
+              className="slds-tabs_path__title"
             >
               Nurturing
             </span>
           </a>
         </li>
         <li
-          className="slds-tabs--path__item slds-is-incomplete"
+          className="slds-tabs_path__item slds-is-incomplete"
           role="presentation"
         >
           <a
             aria-live="assertive"
             aria-selected="false"
-            className="slds-tabs--path__link"
+            className="slds-tabs_path__link"
             onClick={[Function]}
             role="tab"
             tabIndex={-1}
           >
             <span
-              className="slds-tabs--path__stage"
+              className="slds-tabs_path__stage"
             >
               <svg
                 aria-hidden={true}
-                className="slds-icon slds-icon--x-small slds-icon-text-default"
+                className="slds-icon slds-icon_x-small slds-icon-text-default"
               >
                 <use
                   xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#check"
@@ -54591,7 +52879,7 @@ exports[`Storyshots SalesPath Controlled with knobs 1`] = `
               </svg>
             </span>
             <span
-              className="slds-tabs--path__title"
+              className="slds-tabs_path__title"
             >
               Closed
             </span>
@@ -54632,31 +52920,31 @@ exports[`Storyshots SalesPath Default 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-tabs--path"
+      className="slds-tabs_path"
       role="application tablist"
     >
       <ul
-        className="slds-tabs--path__nav"
+        className="slds-tabs_path__nav"
         role="presentation"
       >
         <li
-          className="slds-tabs--path__item slds-is-complete"
+          className="slds-tabs_path__item slds-is-complete"
           role="presentation"
         >
           <a
             aria-live="assertive"
             aria-selected="false"
-            className="slds-tabs--path__link"
+            className="slds-tabs_path__link"
             onClick={[Function]}
             role="tab"
             tabIndex={-1}
           >
             <span
-              className="slds-tabs--path__stage"
+              className="slds-tabs_path__stage"
             >
               <svg
                 aria-hidden={true}
-                className="slds-icon slds-icon--x-small slds-icon-text-default"
+                className="slds-icon slds-icon_x-small slds-icon-text-default"
               >
                 <use
                   xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#check"
@@ -54669,30 +52957,30 @@ exports[`Storyshots SalesPath Default 1`] = `
               </span>
             </span>
             <span
-              className="slds-tabs--path__title"
+              className="slds-tabs_path__title"
             >
               Contacted
             </span>
           </a>
         </li>
         <li
-          className="slds-tabs--path__item slds-is-complete"
+          className="slds-tabs_path__item slds-is-complete"
           role="presentation"
         >
           <a
             aria-live="assertive"
             aria-selected="false"
-            className="slds-tabs--path__link"
+            className="slds-tabs_path__link"
             onClick={[Function]}
             role="tab"
             tabIndex={-1}
           >
             <span
-              className="slds-tabs--path__stage"
+              className="slds-tabs_path__stage"
             >
               <svg
                 aria-hidden={true}
-                className="slds-icon slds-icon--x-small slds-icon-text-default"
+                className="slds-icon slds-icon_x-small slds-icon-text-default"
               >
                 <use
                   xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#check"
@@ -54705,30 +52993,30 @@ exports[`Storyshots SalesPath Default 1`] = `
               </span>
             </span>
             <span
-              className="slds-tabs--path__title"
+              className="slds-tabs_path__title"
             >
               Open
             </span>
           </a>
         </li>
         <li
-          className="slds-tabs--path__item slds-is-current"
+          className="slds-tabs_path__item slds-is-current"
           role="presentation"
         >
           <a
             aria-live="assertive"
             aria-selected="false"
-            className="slds-tabs--path__link"
+            className="slds-tabs_path__link"
             onClick={[Function]}
             role="tab"
             tabIndex={0}
           >
             <span
-              className="slds-tabs--path__stage"
+              className="slds-tabs_path__stage"
             >
               <svg
                 aria-hidden={true}
-                className="slds-icon slds-icon--x-small slds-icon-text-default"
+                className="slds-icon slds-icon_x-small slds-icon-text-default"
               >
                 <use
                   xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#check"
@@ -54736,30 +53024,30 @@ exports[`Storyshots SalesPath Default 1`] = `
               </svg>
             </span>
             <span
-              className="slds-tabs--path__title"
+              className="slds-tabs_path__title"
             >
               Unqualified
             </span>
           </a>
         </li>
         <li
-          className="slds-tabs--path__item slds-is-incomplete"
+          className="slds-tabs_path__item slds-is-incomplete"
           role="presentation"
         >
           <a
             aria-live="assertive"
             aria-selected="false"
-            className="slds-tabs--path__link"
+            className="slds-tabs_path__link"
             onClick={[Function]}
             role="tab"
             tabIndex={-1}
           >
             <span
-              className="slds-tabs--path__stage"
+              className="slds-tabs_path__stage"
             >
               <svg
                 aria-hidden={true}
-                className="slds-icon slds-icon--x-small slds-icon-text-default"
+                className="slds-icon slds-icon_x-small slds-icon-text-default"
               >
                 <use
                   xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#check"
@@ -54767,30 +53055,30 @@ exports[`Storyshots SalesPath Default 1`] = `
               </svg>
             </span>
             <span
-              className="slds-tabs--path__title"
+              className="slds-tabs_path__title"
             >
               Nurturing
             </span>
           </a>
         </li>
         <li
-          className="slds-tabs--path__item slds-is-incomplete"
+          className="slds-tabs_path__item slds-is-incomplete"
           role="presentation"
         >
           <a
             aria-live="assertive"
             aria-selected="false"
-            className="slds-tabs--path__link"
+            className="slds-tabs_path__link"
             onClick={[Function]}
             role="tab"
             tabIndex={-1}
           >
             <span
-              className="slds-tabs--path__stage"
+              className="slds-tabs_path__stage"
             >
               <svg
                 aria-hidden={true}
-                className="slds-icon slds-icon--x-small slds-icon-text-default"
+                className="slds-icon slds-icon_x-small slds-icon-text-default"
               >
                 <use
                   xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#check"
@@ -54798,7 +53086,7 @@ exports[`Storyshots SalesPath Default 1`] = `
               </svg>
             </span>
             <span
-              className="slds-tabs--path__title"
+              className="slds-tabs_path__title"
             >
               Closed
             </span>
@@ -55516,7 +53804,7 @@ exports[`Storyshots Spinner Brand 1`] = `
         >
           <div
             aria-hidden="false"
-            className="slds-spinner slds-spinner--small slds-spinner--brand"
+            className="slds-spinner slds-spinner_small slds-spinner_brand"
             role="alert"
           >
             <div
@@ -55543,7 +53831,7 @@ exports[`Storyshots Spinner Brand 1`] = `
         >
           <div
             aria-hidden="false"
-            className="slds-spinner slds-spinner--medium slds-spinner--brand"
+            className="slds-spinner slds-spinner_medium slds-spinner_brand"
             role="alert"
           >
             <div
@@ -55570,7 +53858,7 @@ exports[`Storyshots Spinner Brand 1`] = `
         >
           <div
             aria-hidden="false"
-            className="slds-spinner slds-spinner--large slds-spinner--brand"
+            className="slds-spinner slds-spinner_large slds-spinner_brand"
             role="alert"
           >
             <div
@@ -55630,7 +53918,7 @@ exports[`Storyshots Spinner Controlled with knobs 1`] = `
       >
         <div
           aria-hidden="false"
-          className="slds-spinner slds-spinner--small"
+          className="slds-spinner slds-spinner_small"
           role="alert"
         >
           <div
@@ -55690,7 +53978,7 @@ exports[`Storyshots Spinner Default 1`] = `
         >
           <div
             aria-hidden="false"
-            className="slds-spinner slds-spinner--small"
+            className="slds-spinner slds-spinner_small"
             role="alert"
           >
             <div
@@ -55717,7 +54005,7 @@ exports[`Storyshots Spinner Default 1`] = `
         >
           <div
             aria-hidden="false"
-            className="slds-spinner slds-spinner--medium"
+            className="slds-spinner slds-spinner_medium"
             role="alert"
           >
             <div
@@ -55744,7 +54032,7 @@ exports[`Storyshots Spinner Default 1`] = `
         >
           <div
             aria-hidden="false"
-            className="slds-spinner slds-spinner--large"
+            className="slds-spinner slds-spinner_large"
             role="alert"
           >
             <div
@@ -55806,7 +54094,7 @@ exports[`Storyshots Spinner Inverse 1`] = `
         >
           <div
             aria-hidden="false"
-            className="slds-spinner slds-spinner--small slds-spinner--inverse"
+            className="slds-spinner slds-spinner_small slds-spinner_inverse"
             role="alert"
           >
             <div
@@ -55834,7 +54122,7 @@ exports[`Storyshots Spinner Inverse 1`] = `
         >
           <div
             aria-hidden="false"
-            className="slds-spinner slds-spinner--medium slds-spinner--inverse"
+            className="slds-spinner slds-spinner_medium slds-spinner_inverse"
             role="alert"
           >
             <div
@@ -55862,7 +54150,7 @@ exports[`Storyshots Spinner Inverse 1`] = `
         >
           <div
             aria-hidden="false"
-            className="slds-spinner slds-spinner--large slds-spinner--inverse"
+            className="slds-spinner slds-spinner_large slds-spinner_inverse"
             role="alert"
           >
             <div
@@ -55899,405 +54187,6 @@ exports[`Storyshots Spinner Inverse 1`] = `
 </div>
 `;
 
-exports[`Storyshots Table Center Align 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <div>
-      <div
-        onScroll={[Function]}
-        style={
-          Object {
-            "overflowX": "auto",
-            "overflowY": "hidden",
-          }
-        }
-      >
-        <table
-          className="slds-table slds-table_cell-buffer slds-table_bordered"
-          style={Object {}}
-        >
-          <thead>
-            <tr
-              className="slds-text-title_caps"
-            >
-              <th
-                className="slds-text-title_caps slds-truncate slds-text-align_center"
-                scope="col"
-                style={
-                  Object {
-                    "minWidth": "auto",
-                  }
-                }
-              >
-                Opportunity Name
-              </th>
-              <th
-                className="slds-text-title_caps slds-truncate slds-text-align_center"
-                scope="col"
-                style={
-                  Object {
-                    "minWidth": "auto",
-                  }
-                }
-              >
-                Account Name
-              </th>
-              <th
-                className="slds-text-title_caps slds-truncate slds-text-align_center"
-                scope="col"
-                style={
-                  Object {
-                    "minWidth": "auto",
-                  }
-                }
-              >
-                Close Date
-              </th>
-              <th
-                className="slds-text-title_caps slds-truncate slds-text-align_center"
-                scope="col"
-                style={
-                  Object {
-                    "minWidth": "auto",
-                  }
-                }
-              >
-                Stage
-              </th>
-              <th
-                className="slds-text-title_caps slds-truncate slds-text-align_center"
-                scope="col"
-                style={
-                  Object {
-                    "minWidth": "auto",
-                  }
-                }
-              >
-                Confidence
-              </th>
-              <th
-                className="slds-text-title_caps slds-truncate slds-text-align_center"
-                scope="col"
-                style={
-                  Object {
-                    "minWidth": "auto",
-                  }
-                }
-              >
-                Amount
-              </th>
-              <th
-                className="slds-text-title_caps slds-truncate slds-text-align_center"
-                scope="col"
-                style={
-                  Object {
-                    "minWidth": "auto",
-                  }
-                }
-              >
-                Contact
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              className="slds-hint-parent"
-            >
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                Cloudhub 1
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                Cloudhub
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                4/14/2015
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                Prospecting
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                20%
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                $25k
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                jrogers@cloudhub.com
-              </td>
-            </tr>
-            <tr
-              className="slds-hint-parent"
-            >
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                Cloudhub 2
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                Cloudhub
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                4/14/2015
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                Prospecting
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                20%
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                $25k
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                jrogers@cloudhub.com
-              </td>
-            </tr>
-            <tr
-              className="slds-hint-parent"
-            >
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                Cloudhub 3
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                Cloudhub
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                4/14/2015
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                Prospecting
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                20%
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                $25k
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                jrogers@cloudhub.com
-              </td>
-            </tr>
-            <tr
-              className="slds-hint-parent"
-            >
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                Cloudhub 4
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                Cloudhub
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                4/14/2015
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                Prospecting
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                20%
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                $25k
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                jrogers@cloudhub.com
-              </td>
-            </tr>
-            <tr
-              className="slds-hint-parent"
-            >
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                Cloudhub 5
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                Cloudhub
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                4/14/2015
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                Prospecting
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                20%
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                $25k
-              </td>
-              <td
-                className="slds-truncate"
-                role="gridcell"
-                style={Object {}}
-              >
-                jrogers@cloudhub.com
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        Default Table component
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Storyshots Table Controlled with knobs 1`] = `
 <div
   className="content-wrapper"
@@ -56317,15 +54206,15 @@ exports[`Storyshots Table Controlled with knobs 1`] = `
         }
       >
         <table
-          className="slds-table slds-table--cell-buffer"
+          className="slds-table slds-table_cell-buffer"
           style={Object {}}
         >
           <thead>
             <tr
-              className="slds-text-title--caps"
+              className="slds-text-title_caps"
             >
               <th
-                className="slds-cell-shrink slds-text-title--caps slds-truncate"
+                className="slds-cell-shrink slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -56334,7 +54223,7 @@ exports[`Storyshots Table Controlled with knobs 1`] = `
                 }
               />
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -56345,7 +54234,7 @@ exports[`Storyshots Table Controlled with knobs 1`] = `
                 Opportunity Name
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -56356,7 +54245,7 @@ exports[`Storyshots Table Controlled with knobs 1`] = `
                 Account Name
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -56367,7 +54256,7 @@ exports[`Storyshots Table Controlled with knobs 1`] = `
                 Close Date
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -56378,7 +54267,7 @@ exports[`Storyshots Table Controlled with knobs 1`] = `
                 Stage
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -56389,7 +54278,7 @@ exports[`Storyshots Table Controlled with knobs 1`] = `
                 Confidence
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -56400,7 +54289,7 @@ exports[`Storyshots Table Controlled with knobs 1`] = `
                 Amount
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -56431,7 +54320,7 @@ exports[`Storyshots Table Controlled with knobs 1`] = `
                 >
                   <button
                     aria-haspopup={true}
-                    className="slds-button slds-button--icon-border slds-button--icon-x-small"
+                    className="slds-button slds-button_icon-border slds-button_icon-x-small"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -56517,7 +54406,7 @@ exports[`Storyshots Table Controlled with knobs 1`] = `
                 >
                   <button
                     aria-haspopup={true}
-                    className="slds-button slds-button--icon-border slds-button--icon-x-small"
+                    className="slds-button slds-button_icon-border slds-button_icon-x-small"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -56603,7 +54492,7 @@ exports[`Storyshots Table Controlled with knobs 1`] = `
                 >
                   <button
                     aria-haspopup={true}
-                    className="slds-button slds-button--icon-border slds-button--icon-x-small"
+                    className="slds-button slds-button_icon-border slds-button_icon-x-small"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -56689,7 +54578,7 @@ exports[`Storyshots Table Controlled with knobs 1`] = `
                 >
                   <button
                     aria-haspopup={true}
-                    className="slds-button slds-button--icon-border slds-button--icon-x-small"
+                    className="slds-button slds-button_icon-border slds-button_icon-x-small"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -56775,7 +54664,7 @@ exports[`Storyshots Table Controlled with knobs 1`] = `
                 >
                   <button
                     aria-haspopup={true}
-                    className="slds-button slds-button--icon-border slds-button--icon-x-small"
+                    className="slds-button slds-button_icon-border slds-button_icon-x-small"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -56890,15 +54779,15 @@ exports[`Storyshots Table Default 1`] = `
         }
       >
         <table
-          className="slds-table slds-table--cell-buffer slds-table--bordered"
+          className="slds-table slds-table_cell-buffer slds-table_bordered"
           style={Object {}}
         >
           <thead>
             <tr
-              className="slds-text-title--caps"
+              className="slds-text-title_caps"
             >
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -56909,7 +54798,7 @@ exports[`Storyshots Table Default 1`] = `
                 Opportunity Name
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -56920,7 +54809,7 @@ exports[`Storyshots Table Default 1`] = `
                 Account Name
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -56931,7 +54820,7 @@ exports[`Storyshots Table Default 1`] = `
                 Close Date
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -56942,7 +54831,7 @@ exports[`Storyshots Table Default 1`] = `
                 Stage
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -56953,7 +54842,7 @@ exports[`Storyshots Table Default 1`] = `
                 Confidence
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -56964,7 +54853,7 @@ exports[`Storyshots Table Default 1`] = `
                 Amount
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -57289,15 +55178,15 @@ exports[`Storyshots Table With Fixed Layout 1`] = `
         }
       >
         <table
-          className="slds-table slds-table--cell-buffer slds-table--bordered slds-table--fixed-layout"
+          className="slds-table slds-table_cell-buffer slds-table_bordered slds-table_fixed-layout"
           style={Object {}}
         >
           <thead>
             <tr
-              className="slds-text-title--caps"
+              className="slds-text-title_caps"
             >
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -57308,7 +55197,7 @@ exports[`Storyshots Table With Fixed Layout 1`] = `
                 Opportunity Name
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -57319,7 +55208,7 @@ exports[`Storyshots Table With Fixed Layout 1`] = `
                 Account Name
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -57330,7 +55219,7 @@ exports[`Storyshots Table With Fixed Layout 1`] = `
                 Close Date
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -57341,7 +55230,7 @@ exports[`Storyshots Table With Fixed Layout 1`] = `
                 Stage
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -57352,7 +55241,7 @@ exports[`Storyshots Table With Fixed Layout 1`] = `
                 Confidence
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -57363,7 +55252,7 @@ exports[`Storyshots Table With Fixed Layout 1`] = `
                 Amount
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -58087,15 +55976,15 @@ exports[`Storyshots Table With No Row Hover 1`] = `
         }
       >
         <table
-          className="slds-table slds-table--cell-buffer slds-table--bordered slds-no-row-hover"
+          className="slds-table slds-table_cell-buffer slds-table_bordered slds-no-row-hover"
           style={Object {}}
         >
           <thead>
             <tr
-              className="slds-text-title--caps"
+              className="slds-text-title_caps"
             >
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -58106,7 +55995,7 @@ exports[`Storyshots Table With No Row Hover 1`] = `
                 Opportunity Name
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -58117,7 +56006,7 @@ exports[`Storyshots Table With No Row Hover 1`] = `
                 Account Name
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -58128,7 +56017,7 @@ exports[`Storyshots Table With No Row Hover 1`] = `
                 Close Date
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -58139,7 +56028,7 @@ exports[`Storyshots Table With No Row Hover 1`] = `
                 Stage
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -58150,7 +56039,7 @@ exports[`Storyshots Table With No Row Hover 1`] = `
                 Confidence
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -58161,7 +56050,7 @@ exports[`Storyshots Table With No Row Hover 1`] = `
                 Amount
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -58486,15 +56375,15 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
         }
       >
         <table
-          className="slds-table slds-table--cell-buffer slds-table--bordered"
+          className="slds-table slds-table_cell-buffer slds-table_bordered"
           style={Object {}}
         >
           <thead>
             <tr
-              className="slds-text-title--caps"
+              className="slds-text-title_caps"
             >
               <th
-                className="slds-text-title--caps slds-truncate slds-is-sortable"
+                className="slds-text-title_caps slds-truncate slds-is-sortable"
                 scope="col"
                 style={
                   Object {
@@ -58503,7 +56392,7 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
                 }
               >
                 <a
-                  className="slds-th__action slds-text-link--reset"
+                  className="slds-th__action slds-text-link_reset"
                   onClick={[Function]}
                 >
                   <span
@@ -58517,11 +56406,11 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
                     Opportunity Name
                   </span>
                   <span
-                    className="slds-icon__container"
+                    className="slds-icon_container"
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-is-sortable__icon"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-is-sortable__icon"
                       style={
                         Object {
                           "position": "absolute",
@@ -58541,7 +56430,7 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
                 </a>
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -58552,7 +56441,7 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
                 Account Name
               </th>
               <th
-                className="slds-text-title--caps slds-truncate slds-is-sortable"
+                className="slds-text-title_caps slds-truncate slds-is-sortable"
                 scope="col"
                 style={
                   Object {
@@ -58561,7 +56450,7 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
                 }
               >
                 <a
-                  className="slds-th__action slds-text-link--reset"
+                  className="slds-th__action slds-text-link_reset"
                   onClick={[Function]}
                 >
                   <span
@@ -58575,11 +56464,11 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
                     Close Date
                   </span>
                   <span
-                    className="slds-icon__container"
+                    className="slds-icon_container"
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-is-sortable__icon"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-is-sortable__icon"
                       style={
                         Object {
                           "position": "absolute",
@@ -58599,7 +56488,7 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
                 </a>
               </th>
               <th
-                className="slds-text-title--caps slds-truncate slds-is-sortable"
+                className="slds-text-title_caps slds-truncate slds-is-sortable"
                 scope="col"
                 style={
                   Object {
@@ -58608,7 +56497,7 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
                 }
               >
                 <a
-                  className="slds-th__action slds-text-link--reset"
+                  className="slds-th__action slds-text-link_reset"
                   onClick={[Function]}
                 >
                   <span
@@ -58622,11 +56511,11 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
                     Stage
                   </span>
                   <span
-                    className="slds-icon__container"
+                    className="slds-icon_container"
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-is-sortable__icon"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-is-sortable__icon"
                       style={
                         Object {
                           "position": "absolute",
@@ -58646,7 +56535,7 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
                 </a>
               </th>
               <th
-                className="slds-text-title--caps slds-truncate slds-is-sortable"
+                className="slds-text-title_caps slds-truncate slds-is-sortable"
                 scope="col"
                 style={
                   Object {
@@ -58655,7 +56544,7 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
                 }
               >
                 <a
-                  className="slds-th__action slds-text-link--reset"
+                  className="slds-th__action slds-text-link_reset"
                   onClick={[Function]}
                 >
                   <span
@@ -58669,11 +56558,11 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
                     Confidence
                   </span>
                   <span
-                    className="slds-icon__container"
+                    className="slds-icon_container"
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-is-sortable__icon"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-is-sortable__icon"
                       style={
                         Object {
                           "position": "absolute",
@@ -58693,7 +56582,7 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
                 </a>
               </th>
               <th
-                className="slds-text-title--caps slds-truncate slds-is-sortable"
+                className="slds-text-title_caps slds-truncate slds-is-sortable"
                 scope="col"
                 style={
                   Object {
@@ -58702,7 +56591,7 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
                 }
               >
                 <a
-                  className="slds-th__action slds-text-link--reset"
+                  className="slds-th__action slds-text-link_reset"
                   onClick={[Function]}
                 >
                   <span
@@ -58716,11 +56605,11 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
                     Amount
                   </span>
                   <span
-                    className="slds-icon__container"
+                    className="slds-icon_container"
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-is-sortable__icon"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-is-sortable__icon"
                       style={
                         Object {
                           "position": "absolute",
@@ -58740,7 +56629,7 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
                 </a>
               </th>
               <th
-                className="slds-text-title--caps slds-truncate slds-is-sortable"
+                className="slds-text-title_caps slds-truncate slds-is-sortable"
                 scope="col"
                 style={
                   Object {
@@ -58749,7 +56638,7 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
                 }
               >
                 <a
-                  className="slds-th__action slds-text-link--reset"
+                  className="slds-th__action slds-text-link_reset"
                   onClick={[Function]}
                 >
                   <span
@@ -58763,11 +56652,11 @@ exports[`Storyshots Table With Sort Enabled 1`] = `
                     Contact
                   </span>
                   <span
-                    className="slds-icon__container"
+                    className="slds-icon_container"
                   >
                     <svg
                       aria-hidden={true}
-                      className="slds-icon slds-icon--x-small slds-icon-text-default slds-is-sortable__icon"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default slds-is-sortable__icon"
                       style={
                         Object {
                           "position": "absolute",
@@ -59101,15 +56990,15 @@ exports[`Storyshots Table With Striped Row 1`] = `
         }
       >
         <table
-          className="slds-table slds-table--cell-buffer slds-table--bordered slds-table--striped"
+          className="slds-table slds-table_cell-buffer slds-table_bordered slds-table_striped"
           style={Object {}}
         >
           <thead>
             <tr
-              className="slds-text-title--caps"
+              className="slds-text-title_caps"
             >
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -59120,7 +57009,7 @@ exports[`Storyshots Table With Striped Row 1`] = `
                 Opportunity Name
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -59131,7 +57020,7 @@ exports[`Storyshots Table With Striped Row 1`] = `
                 Account Name
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -59142,7 +57031,7 @@ exports[`Storyshots Table With Striped Row 1`] = `
                 Close Date
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -59153,7 +57042,7 @@ exports[`Storyshots Table With Striped Row 1`] = `
                 Stage
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -59164,7 +57053,7 @@ exports[`Storyshots Table With Striped Row 1`] = `
                 Confidence
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -59175,7 +57064,7 @@ exports[`Storyshots Table With Striped Row 1`] = `
                 Amount
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -59500,15 +57389,15 @@ exports[`Storyshots Table With Vertical Borders 1`] = `
         }
       >
         <table
-          className="slds-table slds-table--cell-buffer slds-table--bordered slds-table--col-bordered"
+          className="slds-table slds-table_cell-buffer slds-table_bordered slds-table_col-bordered"
           style={Object {}}
         >
           <thead>
             <tr
-              className="slds-text-title--caps"
+              className="slds-text-title_caps"
             >
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -59519,7 +57408,7 @@ exports[`Storyshots Table With Vertical Borders 1`] = `
                 Opportunity Name
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -59530,7 +57419,7 @@ exports[`Storyshots Table With Vertical Borders 1`] = `
                 Account Name
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -59541,7 +57430,7 @@ exports[`Storyshots Table With Vertical Borders 1`] = `
                 Close Date
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -59552,7 +57441,7 @@ exports[`Storyshots Table With Vertical Borders 1`] = `
                 Stage
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -59563,7 +57452,7 @@ exports[`Storyshots Table With Vertical Borders 1`] = `
                 Confidence
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -59574,7 +57463,7 @@ exports[`Storyshots Table With Vertical Borders 1`] = `
                 Amount
               </th>
               <th
-                className="slds-text-title--caps slds-truncate"
+                className="slds-text-title_caps slds-truncate"
                 scope="col"
                 style={
                   Object {
@@ -59889,14 +57778,14 @@ exports[`Storyshots Tabs Controlled with knobs 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-tabs--default"
+      className="slds-tabs_default"
     >
       <ul
-        className="slds-tabs--default__nav"
+        className="slds-tabs_default__nav"
         role="tablist"
       >
         <li
-          className="slds-tabs--default__item slds-text-heading---label"
+          className="slds-tabs_default__item slds-text-heading---label"
           role="presentation"
         >
           <span
@@ -59904,7 +57793,7 @@ exports[`Storyshots Tabs Controlled with knobs 1`] = `
           >
             <a
               aria-selected={false}
-              className="slds-tabs--default__link"
+              className="slds-tabs_default__link"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="tab"
@@ -59915,7 +57804,7 @@ exports[`Storyshots Tabs Controlled with knobs 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs--default__item slds-text-heading---label"
+          className="slds-tabs_default__item slds-text-heading---label"
           role="presentation"
         >
           <span
@@ -59923,7 +57812,7 @@ exports[`Storyshots Tabs Controlled with knobs 1`] = `
           >
             <a
               aria-selected={false}
-              className="slds-tabs--default__link"
+              className="slds-tabs_default__link"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="tab"
@@ -59934,7 +57823,7 @@ exports[`Storyshots Tabs Controlled with knobs 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs--default__item slds-text-heading---label"
+          className="slds-tabs_default__item slds-text-heading---label"
           role="presentation"
         >
           <span
@@ -59942,7 +57831,7 @@ exports[`Storyshots Tabs Controlled with knobs 1`] = `
           >
             <a
               aria-selected={false}
-              className="slds-tabs--default__link"
+              className="slds-tabs_default__link"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="tab"
@@ -60005,14 +57894,14 @@ exports[`Storyshots Tabs Custom Tab Item 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-tabs--default"
+      className="slds-tabs_default"
     >
       <ul
-        className="slds-tabs--default__nav"
+        className="slds-tabs_default__nav"
         role="tablist"
       >
         <li
-          className="slds-tabs--default__item slds-text-heading---label slds-active"
+          className="slds-tabs_default__item slds-text-heading---label slds-active"
           role="presentation"
         >
           <a
@@ -60030,21 +57919,21 @@ exports[`Storyshots Tabs Custom Tab Item 1`] = `
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small slds-icon-standard-account"
+              className="slds-icon slds-icon_small slds-icon-standard-account"
             >
               <use
                 xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#account"
               />
             </svg>
             <span
-              className="slds-p-horizontal--x-small"
+              className="slds-p-horizontal_x-small"
             >
               Tab 1
             </span>
           </a>
         </li>
         <li
-          className="slds-tabs--default__item slds-text-heading---label"
+          className="slds-tabs_default__item slds-text-heading---label"
           role="presentation"
         >
           <a
@@ -60062,21 +57951,21 @@ exports[`Storyshots Tabs Custom Tab Item 1`] = `
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small slds-icon-standard-contact"
+              className="slds-icon slds-icon_small slds-icon-standard-contact"
             >
               <use
                 xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#contact"
               />
             </svg>
             <span
-              className="slds-p-horizontal--x-small"
+              className="slds-p-horizontal_x-small"
             >
               Tab 2
             </span>
           </a>
         </li>
         <li
-          className="slds-tabs--default__item slds-text-heading---label"
+          className="slds-tabs_default__item slds-text-heading---label"
           role="presentation"
         >
           <a
@@ -60094,14 +57983,14 @@ exports[`Storyshots Tabs Custom Tab Item 1`] = `
           >
             <svg
               aria-hidden={true}
-              className="slds-icon slds-icon--small slds-icon-standard-opportunity"
+              className="slds-icon slds-icon_small slds-icon-standard-opportunity"
             >
               <use
                 xlinkHref="/assets/icons/standard-sprite/svg/symbols.svg#opportunity"
               />
             </svg>
             <span
-              className="slds-p-horizontal--x-small"
+              className="slds-p-horizontal_x-small"
             >
               Tab 3
             </span>
@@ -60160,14 +58049,14 @@ exports[`Storyshots Tabs Default 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-tabs--default"
+      className="slds-tabs_default"
     >
       <ul
-        className="slds-tabs--default__nav"
+        className="slds-tabs_default__nav"
         role="tablist"
       >
         <li
-          className="slds-tabs--default__item slds-text-heading---label slds-active"
+          className="slds-tabs_default__item slds-text-heading---label slds-active"
           role="presentation"
         >
           <span
@@ -60175,7 +58064,7 @@ exports[`Storyshots Tabs Default 1`] = `
           >
             <a
               aria-selected={true}
-              className="slds-tabs--default__link"
+              className="slds-tabs_default__link"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="tab"
@@ -60186,7 +58075,7 @@ exports[`Storyshots Tabs Default 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs--default__item slds-text-heading---label"
+          className="slds-tabs_default__item slds-text-heading---label"
           role="presentation"
         >
           <span
@@ -60194,7 +58083,7 @@ exports[`Storyshots Tabs Default 1`] = `
           >
             <a
               aria-selected={false}
-              className="slds-tabs--default__link"
+              className="slds-tabs_default__link"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="tab"
@@ -60205,7 +58094,7 @@ exports[`Storyshots Tabs Default 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs--default__item slds-text-heading---label"
+          className="slds-tabs_default__item slds-text-heading---label"
           role="presentation"
         >
           <span
@@ -60213,7 +58102,7 @@ exports[`Storyshots Tabs Default 1`] = `
           >
             <a
               aria-selected={false}
-              className="slds-tabs--default__link"
+              className="slds-tabs_default__link"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="tab"
@@ -60276,14 +58165,14 @@ exports[`Storyshots Tabs Scoped 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-tabs--scoped"
+      className="slds-tabs_scoped"
     >
       <ul
-        className="slds-tabs--scoped__nav"
+        className="slds-tabs_scoped__nav"
         role="tablist"
       >
         <li
-          className="slds-tabs--scoped__item slds-text-heading---label slds-active"
+          className="slds-tabs_scoped__item slds-text-heading---label slds-active"
           role="presentation"
         >
           <span
@@ -60291,7 +58180,7 @@ exports[`Storyshots Tabs Scoped 1`] = `
           >
             <a
               aria-selected={true}
-              className="slds-tabs--scoped__link"
+              className="slds-tabs_scoped__link"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="tab"
@@ -60302,7 +58191,7 @@ exports[`Storyshots Tabs Scoped 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs--scoped__item slds-text-heading---label"
+          className="slds-tabs_scoped__item slds-text-heading---label"
           role="presentation"
         >
           <span
@@ -60310,7 +58199,7 @@ exports[`Storyshots Tabs Scoped 1`] = `
           >
             <a
               aria-selected={false}
-              className="slds-tabs--scoped__link"
+              className="slds-tabs_scoped__link"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="tab"
@@ -60321,7 +58210,7 @@ exports[`Storyshots Tabs Scoped 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs--scoped__item slds-text-heading---label"
+          className="slds-tabs_scoped__item slds-text-heading---label"
           role="presentation"
         >
           <span
@@ -60329,7 +58218,7 @@ exports[`Storyshots Tabs Scoped 1`] = `
           >
             <a
               aria-selected={false}
-              className="slds-tabs--scoped__link"
+              className="slds-tabs_scoped__link"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="tab"
@@ -60392,14 +58281,14 @@ exports[`Storyshots Tabs With Dropdown (Default) 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-tabs--default"
+      className="slds-tabs_default"
     >
       <ul
-        className="slds-tabs--default__nav"
+        className="slds-tabs_default__nav"
         role="tablist"
       >
         <li
-          className="slds-tabs__item slds-tabs--default__item slds-text-heading---label slds-active react-slds-tab-with-menu"
+          className="slds-tabs__item slds-tabs_default__item slds-text-heading---label slds-active react-slds-tab-with-menu"
           role="presentation"
         >
           <span
@@ -60407,7 +58296,7 @@ exports[`Storyshots Tabs With Dropdown (Default) 1`] = `
           >
             <a
               aria-selected={true}
-              className="slds-tabs--default__link"
+              className="slds-tabs_default__link"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="tab"
@@ -60420,7 +58309,7 @@ exports[`Storyshots Tabs With Dropdown (Default) 1`] = `
             >
               <button
                 aria-haspopup={true}
-                className="slds-button slds-button--icon-bare"
+                className="slds-button slds-button_icon-bare"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -60428,7 +58317,7 @@ exports[`Storyshots Tabs With Dropdown (Default) 1`] = `
               >
                 <svg
                   aria-hidden={true}
-                  className="slds-button__icon slds-button__icon--small"
+                  className="slds-button__icon slds-button__icon_small"
                   pointerEvents="none"
                 >
                   <use
@@ -60440,7 +58329,7 @@ exports[`Storyshots Tabs With Dropdown (Default) 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs__item slds-tabs--default__item slds-text-heading---label react-slds-tab-with-menu"
+          className="slds-tabs__item slds-tabs_default__item slds-text-heading---label react-slds-tab-with-menu"
           role="presentation"
         >
           <span
@@ -60448,7 +58337,7 @@ exports[`Storyshots Tabs With Dropdown (Default) 1`] = `
           >
             <a
               aria-selected={false}
-              className="slds-tabs--default__link"
+              className="slds-tabs_default__link"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="tab"
@@ -60461,7 +58350,7 @@ exports[`Storyshots Tabs With Dropdown (Default) 1`] = `
             >
               <button
                 aria-haspopup={true}
-                className="slds-button slds-button--icon-bare"
+                className="slds-button slds-button_icon-bare"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -60469,7 +58358,7 @@ exports[`Storyshots Tabs With Dropdown (Default) 1`] = `
               >
                 <svg
                   aria-hidden={true}
-                  className="slds-button__icon slds-button__icon--small"
+                  className="slds-button__icon slds-button__icon_small"
                   pointerEvents="none"
                 >
                   <use
@@ -60481,7 +58370,7 @@ exports[`Storyshots Tabs With Dropdown (Default) 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs__item slds-tabs--default__item slds-text-heading---label react-slds-tab-with-menu"
+          className="slds-tabs__item slds-tabs_default__item slds-text-heading---label react-slds-tab-with-menu"
           role="presentation"
         >
           <span
@@ -60489,7 +58378,7 @@ exports[`Storyshots Tabs With Dropdown (Default) 1`] = `
           >
             <a
               aria-selected={false}
-              className="slds-tabs--default__link"
+              className="slds-tabs_default__link"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="tab"
@@ -60502,7 +58391,7 @@ exports[`Storyshots Tabs With Dropdown (Default) 1`] = `
             >
               <button
                 aria-haspopup={true}
-                className="slds-button slds-button--icon-bare"
+                className="slds-button slds-button_icon-bare"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -60510,7 +58399,7 @@ exports[`Storyshots Tabs With Dropdown (Default) 1`] = `
               >
                 <svg
                   aria-hidden={true}
-                  className="slds-button__icon slds-button__icon--small"
+                  className="slds-button__icon slds-button__icon_small"
                   pointerEvents="none"
                 >
                   <use
@@ -60574,14 +58463,14 @@ exports[`Storyshots Tabs With Dropdown (Scoped) 1`] = `
     style={Object {}}
   >
     <div
-      className="slds-tabs--scoped"
+      className="slds-tabs_scoped"
     >
       <ul
-        className="slds-tabs--scoped__nav"
+        className="slds-tabs_scoped__nav"
         role="tablist"
       >
         <li
-          className="slds-tabs__item slds-tabs--scoped__item slds-text-heading---label slds-active react-slds-tab-with-menu"
+          className="slds-tabs__item slds-tabs_scoped__item slds-text-heading---label slds-active react-slds-tab-with-menu"
           role="presentation"
         >
           <span
@@ -60589,7 +58478,7 @@ exports[`Storyshots Tabs With Dropdown (Scoped) 1`] = `
           >
             <a
               aria-selected={true}
-              className="slds-tabs--scoped__link"
+              className="slds-tabs_scoped__link"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="tab"
@@ -60602,7 +58491,7 @@ exports[`Storyshots Tabs With Dropdown (Scoped) 1`] = `
             >
               <button
                 aria-haspopup={true}
-                className="slds-button slds-button--icon-bare"
+                className="slds-button slds-button_icon-bare"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -60610,7 +58499,7 @@ exports[`Storyshots Tabs With Dropdown (Scoped) 1`] = `
               >
                 <svg
                   aria-hidden={true}
-                  className="slds-button__icon slds-button__icon--small"
+                  className="slds-button__icon slds-button__icon_small"
                   pointerEvents="none"
                 >
                   <use
@@ -60622,7 +58511,7 @@ exports[`Storyshots Tabs With Dropdown (Scoped) 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs__item slds-tabs--scoped__item slds-text-heading---label react-slds-tab-with-menu"
+          className="slds-tabs__item slds-tabs_scoped__item slds-text-heading---label react-slds-tab-with-menu"
           role="presentation"
         >
           <span
@@ -60630,7 +58519,7 @@ exports[`Storyshots Tabs With Dropdown (Scoped) 1`] = `
           >
             <a
               aria-selected={false}
-              className="slds-tabs--scoped__link"
+              className="slds-tabs_scoped__link"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="tab"
@@ -60643,7 +58532,7 @@ exports[`Storyshots Tabs With Dropdown (Scoped) 1`] = `
             >
               <button
                 aria-haspopup={true}
-                className="slds-button slds-button--icon-bare"
+                className="slds-button slds-button_icon-bare"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -60651,7 +58540,7 @@ exports[`Storyshots Tabs With Dropdown (Scoped) 1`] = `
               >
                 <svg
                   aria-hidden={true}
-                  className="slds-button__icon slds-button__icon--small"
+                  className="slds-button__icon slds-button__icon_small"
                   pointerEvents="none"
                 >
                   <use
@@ -60663,7 +58552,7 @@ exports[`Storyshots Tabs With Dropdown (Scoped) 1`] = `
           </span>
         </li>
         <li
-          className="slds-tabs__item slds-tabs--scoped__item slds-text-heading---label react-slds-tab-with-menu"
+          className="slds-tabs__item slds-tabs_scoped__item slds-text-heading---label react-slds-tab-with-menu"
           role="presentation"
         >
           <span
@@ -60671,7 +58560,7 @@ exports[`Storyshots Tabs With Dropdown (Scoped) 1`] = `
           >
             <a
               aria-selected={false}
-              className="slds-tabs--scoped__link"
+              className="slds-tabs_scoped__link"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="tab"
@@ -60684,7 +58573,7 @@ exports[`Storyshots Tabs With Dropdown (Scoped) 1`] = `
             >
               <button
                 aria-haspopup={true}
-                className="slds-button slds-button--icon-bare"
+                className="slds-button slds-button_icon-bare"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -60692,7 +58581,7 @@ exports[`Storyshots Tabs With Dropdown (Scoped) 1`] = `
               >
                 <svg
                   aria-hidden={true}
-                  className="slds-button__icon slds-button__icon--small"
+                  className="slds-button__icon slds-button__icon_small"
                   pointerEvents="none"
                 >
                   <use
@@ -60741,43 +58630,6 @@ exports[`Storyshots Tabs With Dropdown (Scoped) 1`] = `
     >
       <p>
         Scoped tabs with dropdown menu
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Text Default 1`] = `
-<div
-  className="content-wrapper"
->
-  <div
-    id="story-root"
-    style={Object {}}
-  >
-    <p
-      className="slds-section-title_divider"
-    >
-      Sample Text
-    </p>
-  </div>
-  <div>
-    <div
-      style={
-        Object {
-          "backgroundColor": "#fff",
-          "borderRadius": "2px",
-          "color": "black",
-          "fontFamily": "Helvetica Neue, Helvetica, Segoe UI, Arial, freesans, sans-serif",
-          "fontSize": "15px",
-          "fontWeight": 300,
-          "lineHeight": 1.45,
-          "padding": "20px 40px 40px",
-        }
-      }
-    >
-      <p>
-        Default Textarea control
       </p>
     </div>
   </div>
@@ -61127,10 +58979,10 @@ exports[`Storyshots Toggle Checked 1`] = `
         className="slds-form-element__control"
       >
         <label
-          className="slds-checkbox--toggle slds-grid"
+          className="slds-checkbox_toggle slds-grid"
         >
           <span
-            className="slds-form-element__label slds-m-bottom--none"
+            className="slds-form-element__label slds-m-bottom_none"
           />
           <input
             aria-describedby="toggle-desc"
@@ -61141,18 +58993,18 @@ exports[`Storyshots Toggle Checked 1`] = `
           />
           <span
             aria-live="assertive"
-            className="slds-checkbox--faux_container"
+            className="slds-checkbox_faux_container"
           >
             <span
-              className="slds-checkbox--faux"
+              className="slds-checkbox_faux"
             />
             <span
-              className="slds-checkbox--on"
+              className="slds-checkbox_on"
             >
               Enabled
             </span>
             <span
-              className="slds-checkbox--off"
+              className="slds-checkbox_off"
             >
               Disabled
             </span>
@@ -61199,10 +59051,10 @@ exports[`Storyshots Toggle Controlled with knobs 1`] = `
         className="slds-form-element__control"
       >
         <label
-          className="slds-checkbox--toggle slds-grid"
+          className="slds-checkbox_toggle slds-grid"
         >
           <span
-            className="slds-form-element__label slds-m-bottom--none"
+            className="slds-form-element__label slds-m-bottom_none"
           >
             Toggle Label
           </span>
@@ -61216,18 +59068,18 @@ exports[`Storyshots Toggle Controlled with knobs 1`] = `
           />
           <span
             aria-live="assertive"
-            className="slds-checkbox--faux_container"
+            className="slds-checkbox_faux_container"
           >
             <span
-              className="slds-checkbox--faux"
+              className="slds-checkbox_faux"
             />
             <span
-              className="slds-checkbox--on"
+              className="slds-checkbox_on"
             >
               Enabled
             </span>
             <span
-              className="slds-checkbox--off"
+              className="slds-checkbox_off"
             >
               Disabled
             </span>
@@ -61274,10 +59126,10 @@ exports[`Storyshots Toggle Default 1`] = `
         className="slds-form-element__control"
       >
         <label
-          className="slds-checkbox--toggle slds-grid"
+          className="slds-checkbox_toggle slds-grid"
         >
           <span
-            className="slds-form-element__label slds-m-bottom--none"
+            className="slds-form-element__label slds-m-bottom_none"
           />
           <input
             aria-describedby="toggle-desc"
@@ -61287,18 +59139,18 @@ exports[`Storyshots Toggle Default 1`] = `
           />
           <span
             aria-live="assertive"
-            className="slds-checkbox--faux_container"
+            className="slds-checkbox_faux_container"
           >
             <span
-              className="slds-checkbox--faux"
+              className="slds-checkbox_faux"
             />
             <span
-              className="slds-checkbox--on"
+              className="slds-checkbox_on"
             >
               Enabled
             </span>
             <span
-              className="slds-checkbox--off"
+              className="slds-checkbox_off"
             >
               Disabled
             </span>
@@ -61345,10 +59197,10 @@ exports[`Storyshots Toggle Disabled 1`] = `
         className="slds-form-element__control"
       >
         <label
-          className="slds-checkbox--toggle slds-grid"
+          className="slds-checkbox_toggle slds-grid"
         >
           <span
-            className="slds-form-element__label slds-m-bottom--none"
+            className="slds-form-element__label slds-m-bottom_none"
           />
           <input
             aria-describedby="toggle-desc"
@@ -61359,18 +59211,18 @@ exports[`Storyshots Toggle Disabled 1`] = `
           />
           <span
             aria-live="assertive"
-            className="slds-checkbox--faux_container"
+            className="slds-checkbox_faux_container"
           >
             <span
-              className="slds-checkbox--faux"
+              className="slds-checkbox_faux"
             />
             <span
-              className="slds-checkbox--on"
+              className="slds-checkbox_on"
             >
               Enabled
             </span>
             <span
-              className="slds-checkbox--off"
+              className="slds-checkbox_off"
             >
               Disabled
             </span>
@@ -61415,7 +59267,7 @@ exports[`Storyshots Tree Controlled with knobs 1`] = `
       role="application"
     >
       <h4
-        className="slds-text-heading--label"
+        className="slds-text-heading_label"
       >
         Tree Example #1
       </h4>
@@ -61439,13 +59291,13 @@ exports[`Storyshots Tree Controlled with knobs 1`] = `
           >
             <button
               aria-controls=""
-              className="slds-m-right--small slds-button slds-button--icon-bare"
+              className="slds-m-right_small slds-button slds-button_icon-bare"
               onClick={[Function]}
               type="button"
             >
               <svg
                 aria-hidden={true}
-                className="slds-button__icon slds-button__icon--small"
+                className="slds-button__icon slds-button__icon_small"
                 pointerEvents="none"
               >
                 <use
@@ -61505,13 +59357,13 @@ exports[`Storyshots Tree Controlled with knobs 1`] = `
               >
                 <button
                   aria-controls=""
-                  className="slds-m-right--small slds-button slds-button--icon-bare"
+                  className="slds-m-right_small slds-button slds-button_icon-bare"
                   onClick={[Function]}
                   type="button"
                 >
                   <svg
                     aria-hidden={true}
-                    className="slds-button__icon slds-button__icon--small"
+                    className="slds-button__icon slds-button__icon_small"
                     pointerEvents="none"
                   >
                     <use

--- a/test/text-spec.tsx
+++ b/test/text-spec.tsx
@@ -9,7 +9,7 @@ describe('Text', () => {
   it('should render badge with category and type', () => {
     const wrapper = shallow(<Text category={category} type={type} />);
     expect(wrapper.prop('className')).toContain(
-      `slds-text-${category}--${type}`
+      `slds-text-${category}_${type}`
     );
   });
   it('should render badge with align', () => {
@@ -17,7 +17,7 @@ describe('Text', () => {
     const wrapper = shallow(
       <Text category={category} type={type} align={align} />
     );
-    expect(wrapper.prop('className')).toContain(`slds-text-align--${align}`);
+    expect(wrapper.prop('className')).toContain(`slds-text-align_${align}`);
   });
   it('should render truncated', () => {
     const wrapper = shallow(<Text category={category} type={type} truncate />);


### PR DESCRIPTION
Some components use old CSS class names, and they'll be deprecated in Spring'21.
https://releasenotes.docs.salesforce.com/en-us/winter21/release-notes/rn_slds_bem_deprecate.htm