### PR TITLE
Enhance DropdownMenu Component to Control Nested Submenu Visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lightning-design-system",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "Salesforce Lightning Design System components built with React",
   "main": "lib/scripts/index.js",
   "module": "module/scripts/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lightning-design-system",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "description": "Salesforce Lightning Design System components built with React",
   "main": "lib/scripts/index.js",
   "module": "module/scripts/index.js",

--- a/src/scripts/DropdownMenu.tsx
+++ b/src/scripts/DropdownMenu.tsx
@@ -366,9 +366,6 @@ const DropdownMenuInner: FC<DropdownMenuProps & AutoAlignInjectedProps> = (
     setOpenSubmenuKeys((prevState) => {
       const newState = { ...prevState };
       Object.keys(newState).forEach((submenuKey) => {
-        // メニューをクリックしてサブメニューを開く、サブメニューをクリックするとそのサブメニューを開く
-        // 開いているメニューをクリックした場合、そのメニューとサブメニューを閉じる
-        // 同じレベルのメニューをクリックした場合、それ以外の同じレベルのメニューとそのサブメニューを閉じる
         if (newState[submenuKey].level >= level && key !== submenuKey) {
           newState[submenuKey].isOpen = false;
         }

--- a/src/scripts/DropdownMenu.tsx
+++ b/src/scripts/DropdownMenu.tsx
@@ -92,7 +92,6 @@ export type DropdownMenuItemProps = {
   onClick?: (e: React.SyntheticEvent) => void;
   submenu?: ReactNode;
   submenuItems?: Array<{ key: string | number } & DropdownMenuItemProps>;
-  openSubmenuKey?: string | number;
   level?: number;
 } & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'onClick'>;
 

--- a/src/scripts/DropdownMenu.tsx
+++ b/src/scripts/DropdownMenu.tsx
@@ -12,6 +12,7 @@ import React, {
   useMemo,
   ReactNode,
   useState,
+  useId,
 } from 'react';
 import classnames from 'classnames';
 import { Icon } from './Icon';
@@ -69,7 +70,9 @@ export const DropdownMenuHandlerContext = createContext<DropdownMenuHandler>(
 );
 
 type OpenSubmenuContext = {
-  openSubmenuKeys: { [key: string]: { isOpen: boolean; level: number } };
+  openSubmenuKeys: {
+    [key: string]: { isOpen: boolean; level: number } | undefined;
+  };
   handleSubmenuOpen: (key: string, level: number) => void;
 };
 
@@ -125,6 +128,8 @@ export const DropdownMenuItem: FC<DropdownMenuItemProps> = (props) => {
 
   const { openSubmenuKeys, handleSubmenuOpen } = useContext(OpenSubmenuContext);
 
+  const submenuKey = useId();
+
   const onKeyDown = useEventCallback((e: KeyboardEvent<HTMLAnchorElement>) => {
     if (e.keyCode === 13 || e.keyCode === 32) {
       // return or space
@@ -176,8 +181,8 @@ export const DropdownMenuItem: FC<DropdownMenuItemProps> = (props) => {
 
   const onMenuItemClick = useEventCallback(
     (e: SyntheticEvent<HTMLAnchorElement>) => {
-      if (submenu && eventKey !== undefined) {
-        handleSubmenuOpen(eventKey.toString(), level + 1);
+      if (submenu) {
+        handleSubmenuOpen(submenuKey, level + 1);
         return;
       }
       onClick?.(e);
@@ -211,8 +216,7 @@ export const DropdownMenuItem: FC<DropdownMenuItemProps> = (props) => {
       </DropdownSubmenu>
     ) : undefined);
 
-  const submenuExpanded =
-    eventKey !== undefined ? openSubmenuKeys[eventKey]?.isOpen ?? false : false;
+  const submenuExpanded = openSubmenuKeys[submenuKey]?.isOpen ?? false;
 
   const menuItemClass = classnames(
     'slds-dropdown__item',

--- a/stories/DropdownMenu.stories.tsx
+++ b/stories/DropdownMenu.stories.tsx
@@ -120,19 +120,48 @@ export const WithSubmenu: StoryObj<StoryProps> = {
         children: 'Menu Item Three',
         submenuItems: [
           {
-            eventKey: 21,
-            key: 21,
+            eventKey: 31,
+            key: 31,
             label: 'Menu Item Three - One',
+            submenuItems: [
+              {
+                eventKey: 311,
+                key: 311,
+                label: 'Menu Item Three - One - One',
+              },
+              {
+                eventKey: 312,
+                key: 312,
+                label: 'Menu Item Three - One - Two',
+              },
+              {
+                eventKey: 313,
+                key: 313,
+                label: 'Menu Item Three - One - Three',
+              },
+            ],
           },
           {
-            eventKey: 22,
-            key: 22,
+            eventKey: 32,
+            key: 32,
             label: 'Menu Item Three - Two',
-          },
-          {
-            eventKey: 23,
-            key: 23,
-            label: 'Menu Item Three - Three',
+            submenuItems: [
+              {
+                eventKey: 321,
+                key: 321,
+                label: 'Menu Item Three - Two - One',
+              },
+              {
+                eventKey: 322,
+                key: 322,
+                label: 'Menu Item Three - Two - Two',
+              },
+              {
+                eventKey: 323,
+                key: 323,
+                label: 'Menu Item Three - Two - Three',
+              },
+            ],
           },
         ],
       },


### PR DESCRIPTION
## Overview
The DropdownMenu component could not control the opening and closing of nested submenus, and when switching between submenus, the original menu remained open.
When a submenu is switched, the original menu should be closed and the newly clicked menu should be opened.

## What I Did
- Manage the opening and closing of all menus with objects
- Move state management to parent component and pass it to child components in context