### PR TITLE
Add optional tooltip prop to Tabs component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lightning-design-system",
-  "version": "5.6.3",
+  "version": "5.6.4",
   "description": "Salesforce Lightning Design System components built with React",
   "main": "lib/scripts/index.js",
   "module": "module/scripts/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lightning-design-system",
-  "version": "5.6.4",
+  "version": "5.6.3",
   "description": "Salesforce Lightning Design System components built with React",
   "main": "lib/scripts/index.js",
   "module": "module/scripts/index.js",

--- a/src/scripts/AutoAlign.tsx
+++ b/src/scripts/AutoAlign.tsx
@@ -435,9 +435,9 @@ export const AutoAlign: FC<AutoAlignProps> = (props) => {
     <div ref={elRef}>
       <RelativePortal
         fullWidth
-        left={adjustedOffsetLeft} // offsetXを適用
+        top={adjustedOffsetTop}
+        left={adjustedOffsetLeft}
         right={-adjustedOffsetLeft}
-        top={adjustedOffsetTop} // offsetYを適用
         onScroll={onScroll}
         component='div'
         className={classnames(portalClassName, additionalPortalClassName)}

--- a/src/scripts/AutoAlign.tsx
+++ b/src/scripts/AutoAlign.tsx
@@ -168,6 +168,8 @@ export type AutoAlignProps = {
   preventPortalize?: boolean;
   align?: Align;
   alignment?: RectangleAlignment;
+  offsetX?: number;
+  offsetY?: number;
   children: (props: AutoAlignInjectedProps) => ReactElement;
 };
 
@@ -398,6 +400,8 @@ export const AutoAlign: FC<AutoAlignProps> = (props) => {
     preventPortalize,
     portalClassName: additionalPortalClassName,
     portalStyle: additionalPortalStyle = {},
+    offsetX = 0,
+    offsetY = 0,
     children,
   } = props;
   const {
@@ -419,6 +423,8 @@ export const AutoAlign: FC<AutoAlignProps> = (props) => {
       right: 0,
     },
   } = compSettings;
+  const adjustedOffsetLeft = offsetLeft + offsetX;
+  const adjustedOffsetTop = offsetTop + offsetY;
   if (typeof children !== 'function') {
     return React.isValidElement(children) ? children : <>{children}</>;
   }
@@ -429,9 +435,9 @@ export const AutoAlign: FC<AutoAlignProps> = (props) => {
     <div ref={elRef}>
       <RelativePortal
         fullWidth
-        left={offsetLeft}
-        right={-offsetLeft}
-        top={offsetTop}
+        left={adjustedOffsetLeft} // offsetXを適用
+        right={-adjustedOffsetLeft}
+        top={adjustedOffsetTop} // offsetYを適用
         onScroll={onScroll}
         component='div'
         className={classnames(portalClassName, additionalPortalClassName)}

--- a/src/scripts/Popover.tsx
+++ b/src/scripts/Popover.tsx
@@ -20,7 +20,7 @@ import { registerStyle } from './util';
 function useInitComponentStyle() {
   useEffect(() => {
     registerStyle('popover', [
-      ['.slds-popover_tooltip a', '{ color: white; }'],
+      ['.react-slds-popover.slds-popover_tooltip a', '{ color: white; }'],
     ]);
   }, []);
 }
@@ -92,6 +92,7 @@ export const PopoverInner = forwardRef<
   const nubbinPosition = alignment.join('-');
   const [firstAlign, secondAlign] = alignment;
   const popoverClassNames = classnames(
+    'react-slds-popover',
     'slds-popover',
     {
       'slds-hide': hidden,

--- a/src/scripts/Popover.tsx
+++ b/src/scripts/Popover.tsx
@@ -68,6 +68,8 @@ export type PopoverProps = {
   theme?: PopoverTheme;
   tooltip?: boolean;
   bodyStyle?: CSSProperties;
+  offsetX?: number;
+  offsetY?: number;
 } & HTMLAttributes<HTMLDivElement>;
 
 /**
@@ -131,7 +133,7 @@ export const PopoverInner = forwardRef<
  *
  */
 export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
-  ({ position, ...props }, ref) => {
+  ({ position, offsetX = 0, offsetY = 0, ...props }, ref) => {
     useInitComponentStyle();
 
     const alignment: RectangleAlignment | undefined = position?.split('-') as
@@ -142,6 +144,8 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
         triggerSelector='.slds-dropdown-trigger'
         alignmentStyle='popover'
         alignment={alignment}
+        offsetX={offsetX}
+        offsetY={offsetY}
       >
         {(injectedProps) => (
           <PopoverInner {...props} {...injectedProps} ref={ref} />

--- a/src/scripts/Popover.tsx
+++ b/src/scripts/Popover.tsx
@@ -4,6 +4,7 @@ import React, {
   FC,
   ReactNode,
   forwardRef,
+  useEffect,
 } from 'react';
 import classnames from 'classnames';
 import {
@@ -11,6 +12,18 @@ import {
   AutoAlignInjectedProps,
   RectangleAlignment,
 } from './AutoAlign';
+import { registerStyle } from './util';
+
+/**
+ *
+ */
+function useInitComponentStyle() {
+  useEffect(() => {
+    registerStyle('popover', [
+      ['.slds-popover_tooltip a', '{ color: white; }'],
+    ]);
+  }, []);
+}
 
 /**
  *
@@ -119,6 +132,8 @@ export const PopoverInner = forwardRef<
  */
 export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
   ({ position, ...props }, ref) => {
+    useInitComponentStyle();
+
     const alignment: RectangleAlignment | undefined = position?.split('-') as
       | RectangleAlignment
       | undefined;

--- a/src/scripts/Tabs.tsx
+++ b/src/scripts/Tabs.tsx
@@ -102,8 +102,8 @@ const TabMenu: FC<TabMenuProps> = (props) => {
 /**
  *
  */
-const TooltipContent = (props: { children: ReactNode; icon: string }) => {
-  const { children, icon } = props;
+const TooltipContent = (props: { children: ReactNode; icon?: string }) => {
+  const { children, icon = 'info' } = props;
   const [isHideTooltip, setIsHideTooltip] = useState(true);
   const popoverRef = useRef<HTMLDivElement>(null);
   const tooltipToggle = useCallback(() => {
@@ -174,14 +174,7 @@ export type TabItemProps<RendererProps extends TabItemRendererProps> = {
 const TabItem = <RendererProps extends TabItemRendererProps>(
   props: TabItemProps<RendererProps>
 ) => {
-  const {
-    title,
-    eventKey,
-    menu,
-    menuIcon,
-    tooltip,
-    tooltipIcon = 'info',
-  } = props;
+  const { title, eventKey, menu, menuIcon, tooltip, tooltipIcon } = props;
   const { type, activeTabRef } = useContext(TabsContext);
   const activeKey = useContext(TabsActiveKeyContext);
   const { onTabClick, onTabKeyDown } = useContext(TabsHandlersContext);

--- a/src/scripts/Tabs.tsx
+++ b/src/scripts/Tabs.tsx
@@ -112,8 +112,7 @@ export type TabItemRendererProps = {
   onTabKeyDown?: Bivariant<
     (eventKey: TabKey, e: React.KeyboardEvent<HTMLAnchorElement>) => void
   >;
-  tooltipText?: string;
-  tooltipContent?: ComponentType<{ tooltipText: string }>;
+  tooltip?: ReactNode;
 };
 
 const DefaultTabItemRenderer: FC<{ children?: ReactNode }> = (props) => {
@@ -138,14 +137,7 @@ export type TabItemProps<RendererProps extends TabItemRendererProps> = {
 const TabItem = <RendererProps extends TabItemRendererProps>(
   props: TabItemProps<RendererProps>
 ) => {
-  const {
-    title,
-    eventKey,
-    menu,
-    menuIcon,
-    tooltipText,
-    tooltipContent: TooltipContent,
-  } = props;
+  const { title, eventKey, menu, menuIcon, tooltip } = props;
   const { type, activeTabRef } = useContext(TabsContext);
   const activeKey = useContext(TabsActiveKeyContext);
   const { onTabClick, onTabKeyDown } = useContext(TabsHandlersContext);
@@ -183,7 +175,7 @@ const TabItem = <RendererProps extends TabItemRendererProps>(
       <TabItemRenderer {...itemRendererProps}>
         <span
           className={`react-slds-tab-item-content ${
-            tooltipText ? 'react-slds-tooltip-enabled' : ''
+            tooltip ? 'react-slds-tooltip-enabled' : ''
           }`}
         >
           <a
@@ -201,12 +193,9 @@ const TabItem = <RendererProps extends TabItemRendererProps>(
           >
             {title}
           </a>
-          {tooltipText && TooltipContent ? (
-            <span
-              className='slds-dropdown-trigger react-slds-tooltip-content'
-              title={tooltipText}
-            >
-              <TooltipContent tooltipText={tooltipText} />
+          {tooltip ? (
+            <span className='slds-dropdown-trigger react-slds-tooltip-content'>
+              {tooltip}
             </span>
           ) : null}
           {menuItems ? (

--- a/src/scripts/Tabs.tsx
+++ b/src/scripts/Tabs.tsx
@@ -122,6 +122,7 @@ const TooltipContent = (props: { children: ReactNode; icon: string }) => {
         hidden={isHideTooltip}
         tabIndex={-1}
         onBlur={onBlur}
+        offsetX={-15}
         tooltip
       >
         {children}

--- a/src/scripts/Tabs.tsx
+++ b/src/scripts/Tabs.tsx
@@ -112,6 +112,8 @@ export type TabItemRendererProps = {
   onTabKeyDown?: Bivariant<
     (eventKey: TabKey, e: React.KeyboardEvent<HTMLAnchorElement>) => void
   >;
+  tooltipText?: string;
+  tooltipContent?: ComponentType<{ tooltipText: string }>;
 };
 
 const DefaultTabItemRenderer: FC<{ children?: ReactNode }> = (props) => {
@@ -136,7 +138,14 @@ export type TabItemProps<RendererProps extends TabItemRendererProps> = {
 const TabItem = <RendererProps extends TabItemRendererProps>(
   props: TabItemProps<RendererProps>
 ) => {
-  const { title, eventKey, menu, menuIcon } = props;
+  const {
+    title,
+    eventKey,
+    menu,
+    menuIcon,
+    tooltipText,
+    tooltipContent: TooltipContent,
+  } = props;
   const { type, activeTabRef } = useContext(TabsContext);
   const activeKey = useContext(TabsActiveKeyContext);
   const { onTabClick, onTabKeyDown } = useContext(TabsHandlersContext);
@@ -172,7 +181,11 @@ const TabItem = <RendererProps extends TabItemRendererProps>(
   return (
     <li className={tabItemClassName} role='presentation'>
       <TabItemRenderer {...itemRendererProps}>
-        <span className='react-slds-tab-item-content'>
+        <span
+          className={`react-slds-tab-item-content ${
+            tooltipText ? 'tooltip-enabled' : ''
+          }`}
+        >
           <a
             className={tabLinkClassName}
             role='tab'
@@ -188,6 +201,14 @@ const TabItem = <RendererProps extends TabItemRendererProps>(
           >
             {title}
           </a>
+          {tooltipText && TooltipContent ? (
+            <span
+              className='slds-dropdown-trigger tooltip-content'
+              title={tooltipText}
+            >
+              <TooltipContent tooltipText={tooltipText} />
+            </span>
+          ) : null}
           {menuItems ? (
             <TabMenu icon={menuIcon} {...menuProps}>
               {menuItems}
@@ -274,7 +295,16 @@ function useInitComponentStyle() {
         '.slds-tabs__item.react-slds-tab-with-menu > .react-slds-tab-item-content > a',
         '{ padding-right: 2rem; }',
       ],
+      [
+        '.slds-tabs__item.react-slds-tab-with-menu > .react-slds-tab-item-content.tooltip-enabled > a',
+        '{ padding-right: 3.5rem; }',
+      ],
       ['.react-slds-tab-menu', '{ position: absolute; top: 0; right: 0; }'],
+      [
+        '.tooltip-content',
+        '{ position: absolute; top: 0.6rem; right: 2.25rem; }',
+      ],
+      ['.slds-popover_tooltip', '{ left: -1rem !important; }'],
       [
         '.react-slds-tab-menu button',
         '{ height: 2.5rem; line-height: 2rem; width: 2rem; visibility: hidden; justify-content: center }',

--- a/src/scripts/Tabs.tsx
+++ b/src/scripts/Tabs.tsx
@@ -183,7 +183,7 @@ const TabItem = <RendererProps extends TabItemRendererProps>(
       <TabItemRenderer {...itemRendererProps}>
         <span
           className={`react-slds-tab-item-content ${
-            tooltipText ? 'tooltip-enabled' : ''
+            tooltipText ? 'react-slds-tooltip-enabled' : ''
           }`}
         >
           <a
@@ -203,7 +203,7 @@ const TabItem = <RendererProps extends TabItemRendererProps>(
           </a>
           {tooltipText && TooltipContent ? (
             <span
-              className='slds-dropdown-trigger tooltip-content'
+              className='slds-dropdown-trigger react-slds-tooltip-content'
               title={tooltipText}
             >
               <TooltipContent tooltipText={tooltipText} />
@@ -296,12 +296,12 @@ function useInitComponentStyle() {
         '{ padding-right: 2rem; }',
       ],
       [
-        '.slds-tabs__item.react-slds-tab-with-menu > .react-slds-tab-item-content.tooltip-enabled > a',
+        '.slds-tabs__item.react-slds-tab-with-menu > .react-slds-tab-item-content.react-slds-tooltip-enabled > a',
         '{ padding-right: 3.5rem; }',
       ],
       ['.react-slds-tab-menu', '{ position: absolute; top: 0; right: 0; }'],
       [
-        '.tooltip-content',
+        '.react-slds-tooltip-content',
         '{ position: absolute; top: 0.6rem; right: 2.25rem; }',
       ],
       ['.slds-popover_tooltip', '{ left: -1rem !important; }'],

--- a/stories/Tabs.stories.tsx
+++ b/stories/Tabs.stories.tsx
@@ -52,17 +52,17 @@ function CustomTabItemContent(props: TabItemRendererProps & { icon: string }) {
   );
 }
 
-function TooltipContent(props: { tooltipText: string }) {
-  const { tooltipText } = props;
+function TooltipContent(props: { text: string }) {
+  const { text } = props;
   const [isHideTooltip, setIsHideTooltip] = useState(true);
   const tooltipToggle = useCallback(() => {
     setIsHideTooltip((hidden) => !hidden);
   }, []);
   return (
     <>
-      <Button type='icon' icon='info' onClick={tooltipToggle} />
+      <Button type='icon' icon='info' onClick={tooltipToggle} title={text} />
       <Popover hidden={isHideTooltip} tooltip>
-        {tooltipText}
+        {text}
       </Popover>
     </>
   );
@@ -218,8 +218,11 @@ export const WithTooltipScoped: ComponentStoryObj<typeof Tabs> = {
         eventKey='1'
         title='Tab 1'
         menuItems={createMenu()}
-        tooltipText='Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
-        tooltipContent={TooltipContent}
+        tooltip={
+          <TooltipContent
+            text={'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'}
+          />
+        }
       >
         This is in tab #1
       </Tab>

--- a/stories/Tabs.stories.tsx
+++ b/stories/Tabs.stories.tsx
@@ -1,12 +1,10 @@
-import React, { FocusEvent, useCallback, useRef, useState } from 'react';
+import React from 'react';
 import {
   Tabs,
   Tab,
   Icon,
   MenuItem,
   TabItemRendererProps,
-  Button,
-  Popover,
 } from '../src/scripts';
 import { ComponentMeta, ComponentStoryObj } from '@storybook/react';
 
@@ -49,43 +47,6 @@ function CustomTabItemContent(props: TabItemRendererProps & { icon: string }) {
       <Icon icon={icon} size='small' />
       <span className='slds-p-horizontal_x-small'>{title}</span>
     </a>
-  );
-}
-
-function TooltipContent(props: { text: string }) {
-  const { text } = props;
-  const [isHideTooltip, setIsHideTooltip] = useState(true);
-  const popoverRef = useRef<HTMLDivElement>(null);
-  const tooltipToggle = useCallback(() => {
-    setIsHideTooltip((hidden) => !hidden);
-  }, []);
-  const onIconBlur = useCallback((e: FocusEvent<HTMLElement>) => {
-    if (popoverRef.current !== e.relatedTarget) {
-      setIsHideTooltip(true);
-    }
-  }, []);
-  const onPopoverBlur = useCallback(() => {
-    setIsHideTooltip(true);
-  }, []);
-  return (
-    <>
-      <Button
-        type='icon'
-        icon='info'
-        onClick={tooltipToggle}
-        onBlur={onIconBlur}
-        title={text}
-      />
-      <Popover
-        ref={popoverRef}
-        hidden={isHideTooltip}
-        tabIndex={-1}
-        onBlur={onPopoverBlur}
-        tooltip
-      >
-        {text}
-      </Popover>
-    </>
   );
 }
 
@@ -240,17 +201,37 @@ export const WithTooltipScoped: ComponentStoryObj<typeof Tabs> = {
         title='Tab 1'
         menuItems={createMenu()}
         tooltip={
-          <TooltipContent
-            text={'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'}
-          />
+          <div>
+            This is a tooltip for tab #1
+            <br />
+            <a
+              href='https://www.example.com/helllo?name=world'
+              target='_blank'
+              rel='noreferrer'
+            >
+              https://www.example.com/helllo?name=world
+            </a>
+          </div>
         }
       >
         This is in tab #1
       </Tab>
-      <Tab eventKey='2' title='Tab 2' menuItems={createMenu()}>
+      <Tab
+        eventKey='2'
+        title='Tab 2'
+        menuItems={createMenu()}
+        tooltip={<div>Warning!</div>}
+        tooltipIcon='warning'
+      >
         This is in tab #2
       </Tab>
-      <Tab eventKey='3' title='Tab 3' menuItems={createMenu()}>
+      <Tab
+        eventKey='3'
+        title='Tab 3'
+        menuItems={createMenu()}
+        tooltip={<div>Error!</div>}
+        tooltipIcon='error'
+      >
         This is in tab #3
       </Tab>
     </Tabs>

--- a/stories/Tabs.stories.tsx
+++ b/stories/Tabs.stories.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   Tabs,
   Tab,
   Icon,
   MenuItem,
   TabItemRendererProps,
+  Button,
+  Popover,
 } from '../src/scripts';
 import { ComponentMeta, ComponentStoryObj } from '@storybook/react';
 
@@ -47,6 +49,22 @@ function CustomTabItemContent(props: TabItemRendererProps & { icon: string }) {
       <Icon icon={icon} size='small' />
       <span className='slds-p-horizontal_x-small'>{title}</span>
     </a>
+  );
+}
+
+function TooltipContent(props: { tooltipText: string }) {
+  const { tooltipText } = props;
+  const [isHideTooltip, setIsHideTooltip] = useState(true);
+  const tooltipToggle = useCallback(() => {
+    setIsHideTooltip((hidden) => !hidden);
+  }, []);
+  return (
+    <>
+      <Button type='icon' icon='info' onClick={tooltipToggle} />
+      <Popover hidden={isHideTooltip} tooltip>
+        {tooltipText}
+      </Popover>
+    </>
   );
 }
 
@@ -177,6 +195,43 @@ export const WithDropdownDefault: ComponentStoryObj<typeof Tabs> = {
 export const WithDropdownScoped: ComponentStoryObj<typeof Tabs> = {
   ...WithDropdownDefault,
   name: 'With Dropdown (Scoped)',
+  args: {
+    type: 'scoped',
+    defaultActiveKey: '1',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Scoped tabs with dropdown menu',
+      },
+    },
+  },
+};
+
+/**
+ *
+ */
+export const WithTooltipScoped: ComponentStoryObj<typeof Tabs> = {
+  render: (args) => (
+    <Tabs {...args}>
+      <Tab
+        eventKey='1'
+        title='Tab 1'
+        menuItems={createMenu()}
+        tooltipText='Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+        tooltipContent={TooltipContent}
+      >
+        This is in tab #1
+      </Tab>
+      <Tab eventKey='2' title='Tab 2' menuItems={createMenu()}>
+        This is in tab #2
+      </Tab>
+      <Tab eventKey='3' title='Tab 3' menuItems={createMenu()}>
+        This is in tab #3
+      </Tab>
+    </Tabs>
+  ),
+  name: 'With Tooltip (Scoped)',
   args: {
     type: 'scoped',
     defaultActiveKey: '1',


### PR DESCRIPTION
## Overview
We want to be able to add an arbitrary tooltip to the `Tabs` component using `Popover`.

<img width="429" alt="image" src="https://github.com/user-attachments/assets/cdc91e3d-16bf-4ca7-80bf-b4731cb56a21">

## What I Did
- ~~Add `tooltipText` and `tooltipContent` as prop.~~
  - Add `tooltip` props (ReactNode) to the Tabs component.
- Tooltip cases added to `Tabs.stories`
- Allow `Popover` to use ref and hide Tooltip when out of focus.