### PR TITLE
Fix preserve button focus during loading state

### DIFF
--- a/src/scripts/TreeNode.tsx
+++ b/src/scripts/TreeNode.tsx
@@ -47,6 +47,7 @@ const TreeNodeItem: FC<TreeNodeProps & { icon?: string }> = (props) => {
     selected,
     leaf,
     opened,
+    level = 0,
     children,
     itemRender: ItemRender,
     onClick,
@@ -58,6 +59,13 @@ const TreeNodeItem: FC<TreeNodeProps & { icon?: string }> = (props) => {
     'slds-is-open': opened,
     'slds-is-selected': selected,
   });
+  const spinnerClassNames = classnames(
+    'react-slds-spinner',
+    'slds-m-right_x-small'
+  );
+  const loadingPositionStyle = {
+    left: `${level}rem`,
+  };
   return (
     <div
       className={itmClassNames}
@@ -65,14 +73,15 @@ const TreeNodeItem: FC<TreeNodeProps & { icon?: string }> = (props) => {
       style={{ position: 'relative' }}
       {...rprops}
     >
-      {loading ? (
+      {loading && (
         <Spinner
+          className={spinnerClassNames}
           container={false}
           size='small'
-          className='slds-m-right_x-small'
-          style={{ position: 'static', marginTop: 14, marginLeft: -2 }}
+          style={loadingPositionStyle}
         />
-      ) : !leaf ? (
+      )}
+      {!leaf ? (
         <Button
           className='slds-m-right_small'
           aria-controls=''
@@ -80,6 +89,8 @@ const TreeNodeItem: FC<TreeNodeProps & { icon?: string }> = (props) => {
           icon={icon}
           iconSize='small'
           onClick={onToggle}
+          // Prevent focus loss during loading by keeping the toggle button in the DOM with opacity set to 0.
+          style={loading ? { opacity: 0, pointerEvents: 'none' } : undefined}
         />
       ) : null}
       <a
@@ -150,7 +161,7 @@ export const TreeNode: FC<TreeNodeProps> = (props) => {
     >
       <TreeNodeItem
         {...rprops}
-        {...{ leaf, opened, children, onClick, onLabelClick, onToggle }}
+        {...{ leaf, opened, level, children, onClick, onLabelClick, onToggle }}
       />
       {!leaf ? (
         <ul className={grpClassNames} role='group'>


### PR DESCRIPTION
## Summary
In scenarios where child tree nodes are fetched and displayed during field lookups, clicking the toggle caused the tree to collapse. 
This issue was due to the button becoming hidden and losing focus during loading. 

This fix ensures that the button remains visible and retains focus during the loading state, preventing the tree from closing unexpectedly.

## What I did
- Kept the button visible during loading by setting its `opacity: 0`, ensuring it retains focus.
- Positioned the Spinner with `position: absolute` to overlay it on the button.