### PR TITLE
Move `required` mark's position

### DIFF
--- a/src/scripts/CheckboxGroup.tsx
+++ b/src/scripts/CheckboxGroup.tsx
@@ -112,8 +112,8 @@ export const CheckboxGroup = createFC<
         onChange={onChange}
       >
         <legend className='slds-form-element__label'>
-          {label}
           {required ? <abbr className='slds-required'>*</abbr> : undefined}
+          {label}
         </legend>
         <div className='slds-form-element__control' ref={controlElRef}>
           <CheckboxGroupContext.Provider value={grpCtx}>

--- a/src/scripts/FormElement.tsx
+++ b/src/scripts/FormElement.tsx
@@ -100,8 +100,8 @@ export const FormElement = createFC<
               htmlFor={id}
               onClick={id ? undefined : onClickLabel}
             >
-              {label}
               {required ? <abbr className='slds-required'>*</abbr> : undefined}
+              {label}
             </label>
           ) : null}
           {tooltip ? (

--- a/src/scripts/RadioGroup.tsx
+++ b/src/scripts/RadioGroup.tsx
@@ -90,8 +90,8 @@ export const RadioGroup = createFC<RadioGroupProps, { isFormElement: boolean }>(
         {...rprops}
       >
         <legend className='slds-form-element__label'>
-          {label}
           {required ? <abbr className='slds-required'>*</abbr> : undefined}
+          {label}
         </legend>
         <div className='slds-form-element__control'>
           <RadioGroupContext.Provider value={grpCtx}>


### PR DESCRIPTION
# Summary
Moved `required` mark's position from right to left, in order to follow the latest SLDS's way.

# Reference
https://www.lightningdesignsystem.com/components/input/#Required