### PR TITLE
Changed to accept tooltips in components that use FormElement internally

### DIFF
--- a/src/scripts/Checkbox.tsx
+++ b/src/scripts/Checkbox.tsx
@@ -1,4 +1,10 @@
-import React, { FC, InputHTMLAttributes, Ref, useContext } from 'react';
+import React, {
+  FC,
+  InputHTMLAttributes,
+  Ref,
+  useContext,
+  ReactNode,
+} from 'react';
 import classnames from 'classnames';
 import { FormElement, FormElementProps } from './FormElement';
 import { CheckboxGroupContext, CheckboxValueType } from './CheckboxGroup';
@@ -15,6 +21,8 @@ export type CheckboxProps = {
   value?: CheckboxValueType;
   checked?: boolean;
   defaultChecked?: boolean;
+  tooltip?: ReactNode;
+  tooltipIcon?: string;
   elementRef?: Ref<HTMLDivElement>;
   inputRef?: Ref<HTMLInputElement>;
 } & InputHTMLAttributes<HTMLInputElement>;
@@ -30,13 +38,22 @@ export const Checkbox: FC<CheckboxProps> = (props) => {
     required,
     error,
     cols,
+    tooltip,
+    tooltipIcon,
     elementRef,
     inputRef,
     children,
     ...rprops
   } = props;
   const { grouped } = useContext(CheckboxGroupContext);
-  const formElemProps = { required, error, cols, elementRef };
+  const formElemProps = {
+    required,
+    error,
+    cols,
+    tooltip,
+    tooltipIcon,
+    elementRef,
+  };
   const checkClassNames = classnames(className, 'slds-checkbox');
   const check = (
     <label className={checkClassNames}>

--- a/src/scripts/CheckboxGroup.tsx
+++ b/src/scripts/CheckboxGroup.tsx
@@ -117,19 +117,19 @@ export const CheckboxGroup = createFC<
         {...rprops}
         onChange={onChange}
       >
-        <div className='slds-grid slds-grid_vertical-align-center'>
-          <legend className='slds-form-element__label'>
-            {required ? (
-              <abbr className='slds-required' title='required'>
-                *
-              </abbr>
-            ) : undefined}
-            {label}
-          </legend>
+        <legend className='slds-form-element__label'>
+          {required ? (
+            <abbr className='slds-required' title='required'>
+              *
+            </abbr>
+          ) : undefined}
+          {label}
           {tooltip ? (
-            <TooltipContent icon={tooltipIcon}>{tooltip}</TooltipContent>
+            <span className='slds-m-left_x-small'>
+              <TooltipContent icon={tooltipIcon}>{tooltip}</TooltipContent>
+            </span>
           ) : null}
-        </div>
+        </legend>
         <div className='slds-form-element__control' ref={controlElRef}>
           <CheckboxGroupContext.Provider value={grpCtx}>
             {children}

--- a/src/scripts/CheckboxGroup.tsx
+++ b/src/scripts/CheckboxGroup.tsx
@@ -5,10 +5,12 @@ import React, {
   useContext,
   useMemo,
   useRef,
+  ReactNode,
 } from 'react';
 import classnames from 'classnames';
 import { FormElementProps } from './FormElement';
 import { FieldSetColumnContext } from './FieldSet';
+import { TooltipContent } from './TooltipContent';
 import { useEventCallback } from './hooks';
 import { createFC } from './common';
 import { Bivariant } from './typeUtils';
@@ -32,6 +34,8 @@ export type CheckboxGroupProps = {
   error?: FormElementProps['error'];
   name?: string;
   cols?: number;
+  tooltip?: ReactNode;
+  tooltipIcon?: string;
   elementRef?: Ref<HTMLFieldSetElement>;
   onValueChange?: Bivariant<(values: CheckboxValueType[]) => void>;
 } & FieldsetHTMLAttributes<HTMLFieldSetElement>;
@@ -51,6 +55,8 @@ export const CheckboxGroup = createFC<
       style,
       required,
       error,
+      tooltip,
+      tooltipIcon,
       elementRef,
       onValueChange,
       onChange: onChange_,
@@ -111,14 +117,19 @@ export const CheckboxGroup = createFC<
         {...rprops}
         onChange={onChange}
       >
-        <legend className='slds-form-element__label'>
-          {required ? (
-            <abbr className='slds-required' title='required'>
-              *
-            </abbr>
-          ) : undefined}
-          {label}
-        </legend>
+        <div className='slds-grid slds-grid_vertical-align-center'>
+          <legend className='slds-form-element__label'>
+            {required ? (
+              <abbr className='slds-required' title='required'>
+                *
+              </abbr>
+            ) : undefined}
+            {label}
+          </legend>
+          {tooltip ? (
+            <TooltipContent icon={tooltipIcon}>{tooltip}</TooltipContent>
+          ) : null}
+        </div>
         <div className='slds-form-element__control' ref={controlElRef}>
           <CheckboxGroupContext.Provider value={grpCtx}>
             {children}

--- a/src/scripts/DateInput.tsx
+++ b/src/scripts/DateInput.tsx
@@ -8,6 +8,7 @@ import React, {
   useRef,
   useState,
   useContext,
+  ReactNode,
 } from 'react';
 import classnames from 'classnames';
 import dayjs from 'dayjs';
@@ -118,6 +119,8 @@ export type DateInputProps = {
   minDate?: string;
   maxDate?: string;
   menuAlign?: 'left' | 'right';
+  tooltip?: ReactNode;
+  tooltipIcon?: string;
   elementRef?: Ref<HTMLDivElement>;
   datepickerRef?: Ref<HTMLDivElement>;
   onBlur?: () => void;
@@ -149,6 +152,8 @@ export const DateInput = createFC<DateInputProps, { isFormElement: boolean }>(
       minDate,
       maxDate,
       extensionRenderer,
+      tooltip,
+      tooltipIcon,
       elementRef: elementRef_,
       inputRef: inputRef_,
       datepickerRef: datepickerRef_,
@@ -316,7 +321,16 @@ export const DateInput = createFC<DateInputProps, { isFormElement: boolean }>(
       }
     });
 
-    const formElemProps = { id, cols, label, required, error, elementRef };
+    const formElemProps = {
+      id,
+      cols,
+      label,
+      required,
+      error,
+      tooltip,
+      tooltipIcon,
+      elementRef,
+    };
     return (
       <FormElement {...formElemProps}>
         <div className={classnames(className, 'slds-dropdown-trigger')}>

--- a/src/scripts/Input.tsx
+++ b/src/scripts/Input.tsx
@@ -7,6 +7,7 @@ import React, {
   useContext,
   Ref,
   useRef,
+  ReactNode,
 } from 'react';
 import classnames from 'classnames';
 import keycoder from 'keycoder';
@@ -92,6 +93,8 @@ export type InputProps = {
   iconRight?: string | JSX.Element;
   addonLeft?: string;
   addonRight?: string;
+  tooltip?: ReactNode;
+  tooltipIcon?: string;
   elementRef?: Ref<HTMLDivElement>;
   inputRef?: Ref<HTMLInputElement>;
   onValueChange?: (value: string, prevValue?: string) => void;
@@ -120,6 +123,8 @@ export const Input = createFC<InputProps, { isFormElement: boolean }>(
       addonLeft,
       addonRight,
       symbolPattern,
+      tooltip,
+      tooltipIcon,
       elementRef,
       inputRef,
       onKeyDown: onKeyDown_,
@@ -207,6 +212,8 @@ export const Input = createFC<InputProps, { isFormElement: boolean }>(
         error,
         readOnly,
         cols,
+        tooltip,
+        tooltipIcon,
         elementRef,
       };
       return <FormElement {...formElemProps}>{contentElem}</FormElement>;

--- a/src/scripts/Lookup.tsx
+++ b/src/scripts/Lookup.tsx
@@ -11,6 +11,7 @@ import React, {
   useState,
   useEffect,
   EventHandler,
+  ReactNode,
 } from 'react';
 import classnames from 'classnames';
 import { AutoAlign, AutoAlignInjectedProps, AutoAlignProps } from './AutoAlign';
@@ -571,6 +572,8 @@ export type LookupProps = {
   targetScope?: string;
   defaultTargetScope?: string;
   cols?: number;
+  tooltip?: ReactNode;
+  tooltipIcon?: string;
 
   elementRef?: Ref<HTMLDivElement>;
   inputRef?: Ref<HTMLDivElement>;
@@ -619,6 +622,8 @@ export const Lookup = createFC<LookupProps, { isFormElement: boolean }>(
       listFooter,
       data,
       scopes,
+      tooltip,
+      tooltipIcon,
       onSelect: onSelect_,
       onScopeMenuClick: onScopeMenuClick_,
       onScopeSelect: onScopeSelect_,
@@ -763,7 +768,15 @@ export const Lookup = createFC<LookupProps, { isFormElement: boolean }>(
       { 'slds-has-selection': selected },
       className
     );
-    const formElemProps = { id, cols, label, required, error };
+    const formElemProps = {
+      id,
+      cols,
+      label,
+      required,
+      error,
+      tooltip,
+      tooltipIcon,
+    };
     return (
       <FormElement {...formElemProps}>
         <div

--- a/src/scripts/Picklist.tsx
+++ b/src/scripts/Picklist.tsx
@@ -5,6 +5,7 @@ import React, {
   useContext,
   useRef,
   Ref,
+  ReactNode,
 } from 'react';
 import classnames from 'classnames';
 import { FormElement, FormElementProps } from './FormElement';
@@ -57,6 +58,8 @@ export type PicklistProps<MultiSelect extends boolean | undefined> = {
   disabled?: boolean;
   menuSize?: DropdownMenuProps['size'];
   menuStyle?: CSSProperties;
+  tooltip?: ReactNode;
+  tooltipIcon?: string;
   elementRef?: Ref<HTMLDivElement>;
   dropdownRef?: Ref<HTMLDivElement>;
   onValueChange?: Bivariant<
@@ -98,6 +101,8 @@ export const Picklist: (<MultiSelect extends boolean | undefined>(
       required,
       error,
       cols,
+      tooltip,
+      tooltipIcon,
       elementRef: elementRef_,
       buttonRef: buttonRef_,
       dropdownRef: dropdownRef_,
@@ -294,6 +299,8 @@ export const Picklist: (<MultiSelect extends boolean | undefined>(
       required,
       error,
       cols,
+      tooltip,
+      tooltipIcon,
       elementRef,
     };
     return (

--- a/src/scripts/RadioGroup.tsx
+++ b/src/scripts/RadioGroup.tsx
@@ -4,9 +4,11 @@ import React, {
   createContext,
   useContext,
   useMemo,
+  ReactNode,
 } from 'react';
 import classnames from 'classnames';
 import { FieldSetColumnContext } from './FieldSet';
+import { TooltipContent } from './TooltipContent';
 import { createFC } from './common';
 import { Bivariant } from './typeUtils';
 
@@ -32,6 +34,8 @@ export type RadioGroupProps = {
   error?: boolean | string | { message: string };
   name?: string;
   cols?: number;
+  tooltip?: ReactNode;
+  tooltipIcon?: string;
   elementRef?: Ref<HTMLFieldSetElement>;
   onValueChange?: Bivariant<(value: RadioValueType) => void>;
 } & HTMLAttributes<HTMLFieldSetElement>;
@@ -50,6 +54,8 @@ export const RadioGroup = createFC<RadioGroupProps, { isFormElement: boolean }>(
       style,
       children,
       name,
+      tooltip,
+      tooltipIcon,
       elementRef,
       onValueChange,
       ...rprops
@@ -89,14 +95,19 @@ export const RadioGroup = createFC<RadioGroupProps, { isFormElement: boolean }>(
         style={grpStyles}
         {...rprops}
       >
-        <legend className='slds-form-element__label'>
-          {required ? (
-            <abbr className='slds-required' title='required'>
-              *
-            </abbr>
-          ) : undefined}
-          {label}
-        </legend>
+        <div className='slds-grid slds-grid_vertical-align-center'>
+          <legend className='slds-form-element__label'>
+            {required ? (
+              <abbr className='slds-required' title='required'>
+                *
+              </abbr>
+            ) : undefined}
+            {label}
+          </legend>
+          {tooltip ? (
+            <TooltipContent icon={tooltipIcon}>{tooltip}</TooltipContent>
+          ) : null}
+        </div>
         <div className='slds-form-element__control'>
           <RadioGroupContext.Provider value={grpCtx}>
             {children}

--- a/src/scripts/RadioGroup.tsx
+++ b/src/scripts/RadioGroup.tsx
@@ -95,19 +95,19 @@ export const RadioGroup = createFC<RadioGroupProps, { isFormElement: boolean }>(
         style={grpStyles}
         {...rprops}
       >
-        <div className='slds-grid slds-grid_vertical-align-center'>
-          <legend className='slds-form-element__label'>
-            {required ? (
-              <abbr className='slds-required' title='required'>
-                *
-              </abbr>
-            ) : undefined}
-            {label}
-          </legend>
+        <legend className='slds-form-element__label'>
+          {required ? (
+            <abbr className='slds-required' title='required'>
+              *
+            </abbr>
+          ) : undefined}
+          {label}
           {tooltip ? (
-            <TooltipContent icon={tooltipIcon}>{tooltip}</TooltipContent>
+            <span className='slds-m-left_x-small'>
+              <TooltipContent icon={tooltipIcon}>{tooltip}</TooltipContent>
+            </span>
           ) : null}
-        </div>
+        </legend>
         <div className='slds-form-element__control'>
           <RadioGroupContext.Provider value={grpCtx}>
             {children}

--- a/src/scripts/Select.tsx
+++ b/src/scripts/Select.tsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
   ChangeEvent,
   FC,
+  ReactNode,
 } from 'react';
 import classnames from 'classnames';
 import { FormElement, FormElementProps } from './FormElement';
@@ -21,6 +22,8 @@ export type SelectProps = {
   required?: boolean;
   cols?: number;
   error?: FormElementProps['error'];
+  tooltip?: ReactNode;
+  tooltipIcon?: string;
   elementRef?: Ref<HTMLDivElement>;
   selectRef?: Ref<HTMLSelectElement>;
   onValueChange?: (value: string, prevValue?: string) => void;
@@ -38,6 +41,8 @@ export const Select = createFC<SelectProps, { isFormElement: boolean }>(
       required,
       error,
       cols,
+      tooltip,
+      tooltipIcon,
       elementRef,
       selectRef,
       children,
@@ -65,7 +70,16 @@ export const Select = createFC<SelectProps, { isFormElement: boolean }>(
       </select>
     );
     if (isFieldSetColumn || label || required || error || cols) {
-      const formElemProps = { id, label, required, error, cols, elementRef };
+      const formElemProps = {
+        id,
+        label,
+        required,
+        error,
+        cols,
+        tooltip,
+        tooltipIcon,
+        elementRef,
+      };
       return <FormElement {...formElemProps}>{selectElem}</FormElement>;
     }
     return selectElem;

--- a/src/scripts/Textarea.tsx
+++ b/src/scripts/Textarea.tsx
@@ -1,5 +1,6 @@
 import React, {
   ChangeEvent,
+  ReactNode,
   Ref,
   TextareaHTMLAttributes,
   useContext,
@@ -19,6 +20,8 @@ export type TextareaProps = {
   required?: boolean;
   error?: FormElementProps['error'];
   cols?: number;
+  tooltip?: ReactNode;
+  tooltipIcon?: string;
   elementRef?: Ref<HTMLDivElement>;
   textareaRef?: Ref<HTMLTextAreaElement>;
   onValueChange?: (value: string, prevValue?: string) => void;
@@ -36,6 +39,8 @@ export const Textarea = createFC<TextareaProps, { isFormElement: boolean }>(
       required,
       error,
       cols,
+      tooltip,
+      tooltipIcon,
       elementRef,
       textareaRef,
       onChange: onChange_,
@@ -60,7 +65,16 @@ export const Textarea = createFC<TextareaProps, { isFormElement: boolean }>(
       />
     );
     if (isFieldSetColumn || label || required || error || cols) {
-      const formElemProps = { id, label, required, error, cols, elementRef };
+      const formElemProps = {
+        id,
+        label,
+        required,
+        error,
+        cols,
+        tooltip,
+        tooltipIcon,
+        elementRef,
+      };
       return <FormElement {...formElemProps}>{textareaElem}</FormElement>;
     }
     return textareaElem;

--- a/stories/Checkbox.stories.tsx
+++ b/stories/Checkbox.stories.tsx
@@ -176,3 +176,33 @@ export const Disabled: StoryObj<StoryProps> = {
     },
   },
 };
+
+/**
+ *
+ */
+export const WithTooltip: StoryObj<StoryProps> = {
+  render: ({ checkbox1, checkbox2, ...args }) => (
+    <CheckboxGroup {...args}>
+      <Checkbox {...checkbox1} />
+      <Checkbox {...checkbox2} />
+    </CheckboxGroup>
+  ),
+  name: 'With tooltip',
+  args: {
+    label: 'Checkbox Group Label',
+    tooltip: 'Tooltip Text',
+    checkbox1: {
+      label: 'Checkbox Label One',
+      value: '1',
+    },
+    checkbox2: {
+      label: 'Checkbox Label Two',
+      value: '2',
+    },
+  },
+  parameters: {
+    docs: {
+      storyDescription: 'Checkbox group with tooltip',
+    },
+  },
+};

--- a/stories/DateInput.stories.tsx
+++ b/stories/DateInput.stories.tsx
@@ -175,3 +175,21 @@ export const IncludeTimeData: ComponentStoryObj<typeof DateInput> = {
     },
   },
 };
+
+/**
+ *
+ */
+export const WithTooltip: ComponentStoryObj<typeof DateInput> = {
+  name: 'With tooltip',
+  args: {
+    label: 'Date Input Label',
+    tooltip: 'Tooltip Text',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Date input control with tooltip',
+      },
+    },
+  },
+};

--- a/stories/Input.stories.tsx
+++ b/stories/Input.stories.tsx
@@ -253,3 +253,20 @@ export const ReadOnlyWithFixedText: ComponentStoryObj<typeof Input> = {
     },
   },
 };
+
+/**
+ *
+ */
+export const WithTooltip: ComponentStoryObj<typeof Input> = {
+  name: 'With tooltip',
+  args: {
+    label: 'Input Label',
+    placeholder: 'Placeholder Text',
+    tooltip: 'Tooltip Text',
+  },
+  parameters: {
+    docs: {
+      storyDescription: 'Input control with tooltip',
+    },
+  },
+};

--- a/stories/Lookup.stories.tsx
+++ b/stories/Lookup.stories.tsx
@@ -654,3 +654,22 @@ export const UncontrolledWithMultiScope: ComponentStoryObj<typeof Lookup> = {
     },
   },
 };
+
+/**
+ *
+ */
+export const WithTooltip: ComponentStoryObj<typeof Lookup> = {
+  name: 'With tooltip',
+  args: {
+    label: 'Lookup Label',
+    tooltip: 'Tooltip Text',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Lookup component with tooltip',
+      },
+      iframeHeight: 120,
+    },
+  },
+};

--- a/stories/Picklist.stories.tsx
+++ b/stories/Picklist.stories.tsx
@@ -250,3 +250,21 @@ export const DropdownScroll: ComponentStoryObj<typeof Picklist> = {
     },
   },
 };
+
+/**
+ *
+ */
+export const WithTooltip: ComponentStoryObj<typeof Picklist> = {
+  name: 'With tooltip',
+  args: {
+    ...ControlledWithKnobs.args,
+    tooltip: 'Tooltip Text',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Picklist control with tooltip',
+      },
+    },
+  },
+};

--- a/stories/Radio.stories.tsx
+++ b/stories/Radio.stories.tsx
@@ -136,3 +136,26 @@ export const Disabled: StoryObj<StoryProps> = {
     },
   },
 };
+
+/**
+ *
+ */
+export const WithTooltip: StoryObj<StoryProps> = {
+  render: (args) => (
+    <RadioGroup {...args}>
+      <Radio label='Radio Label One' value='1' />
+      <Radio label='Radio Label Two' value='2' />
+    </RadioGroup>
+  ),
+  args: {
+    label: 'Radio Group Label',
+    tooltip: 'Tooltip Text',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Radio Group control with tooltip',
+      },
+    },
+  },
+};

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -196,3 +196,22 @@ export const MultipleDisabled: ComponentStoryObj<typeof Select> = {
     },
   },
 };
+
+/**
+ *
+ */
+export const WithTooltip: ComponentStoryObj<typeof Select> = {
+  ...Default,
+  name: 'With tooltip',
+  args: {
+    label: 'Select Label',
+    tooltip: 'Tooltip Text',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Select control with tooltip',
+      },
+    },
+  },
+};

--- a/stories/Textarea.stories.tsx
+++ b/stories/Textarea.stories.tsx
@@ -122,3 +122,21 @@ export const ReadOnly: ComponentStoryObj<typeof Textarea> = {
     },
   },
 };
+
+/**
+ *
+ */
+export const WithTooltip: ComponentStoryObj<typeof Textarea> = {
+  name: 'With tooltip',
+  args: {
+    label: 'Textarea Label',
+    tooltip: 'Tooltip Text',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Textarea control with tooltip',
+      },
+    },
+  },
+};


### PR DESCRIPTION
Closes #451 

## What I did
- Add `tooltip` and `tooltipIcon` acceptance in components that use FormElement internally: 772046e7d9fde4e9d13484eb34af76769c602871
  - `Input/Textarea/Select/Picklist/Lookup/DateInput/Checkbox`
- Add `TooltipContent` to `CheckboxGroup` and `RadioGroup` to accept it: 2066d28440eb8b2a9a3cd6d95d8e6431aa408c92
- Add stories with tooltip