### PR TITLE
Update `BreadCrumbs` for SLDS2

### DIFF
--- a/src/scripts/BreadCrumbs.tsx
+++ b/src/scripts/BreadCrumbs.tsx
@@ -18,10 +18,7 @@ export const Crumb: FC<CrumbProps> = ({
   ...props
 }) => {
   const text = children;
-  const cClassName = classnames(
-    'slds-list__item slds-text-heading_label',
-    className
-  );
+  const cClassName = classnames('slds-breadcrumb__item', className);
 
   return (
     <li {...props} className={cClassName}>
@@ -44,7 +41,9 @@ export const BreadCrumbs: FC<BreadCrumbsProps> = ({
   ...props
 }) => {
   const oClassName = classnames(
-    'slds-breadcrumb slds-list_horizontal',
+    'slds-breadcrumb',
+    'slds-list_horizontal',
+    'slds-wrap',
     className
   );
 


### PR DESCRIPTION
# What I did

- remove `.slds-assistive-text`
- add an `aria-label` attribute
- update classnames

# Reference

https://v1.lightningdesignsystem.com/components/breadcrumbs/