### PR TITLE
Update `Badge` for SLDS2

### DIFF
--- a/src/scripts/Badge.tsx
+++ b/src/scripts/Badge.tsx
@@ -5,7 +5,7 @@ import classnames from 'classnames';
  *
  */
 export type BadgeProps = {
-  type?: 'default' | 'shade' | 'inverse';
+  type?: 'shade' | 'inverse';
   label?: string;
 } & HTMLAttributes<HTMLSpanElement>;
 

--- a/src/scripts/Badge.tsx
+++ b/src/scripts/Badge.tsx
@@ -13,7 +13,7 @@ export type BadgeProps = {
  *
  */
 export const Badge: FC<BadgeProps> = ({ type, label, ...props }) => {
-  const typeClassName = type ? `slds-theme_${type}` : null;
+  const typeClassName = type ? `slds-badge_${type}` : null;
   const badgeClassNames = classnames('slds-badge', typeClassName);
   return (
     <span className={badgeClassNames} {...props}>

--- a/src/scripts/Badge.tsx
+++ b/src/scripts/Badge.tsx
@@ -5,7 +5,7 @@ import classnames from 'classnames';
  *
  */
 export type BadgeProps = {
-  type?: 'shade' | 'inverse';
+  type?: 'inverse';
   label?: string;
 } & HTMLAttributes<HTMLSpanElement>;
 

--- a/src/scripts/Badge.tsx
+++ b/src/scripts/Badge.tsx
@@ -5,7 +5,7 @@ import classnames from 'classnames';
  *
  */
 export type BadgeProps = {
-  type?: 'inverse';
+  type?: 'inverse' | 'lightest' | 'success' | 'warning' | 'error';
   label?: string;
 } & HTMLAttributes<HTMLSpanElement>;
 
@@ -13,8 +13,17 @@ export type BadgeProps = {
  *
  */
 export const Badge: FC<BadgeProps> = ({ type, label, ...props }) => {
-  const typeClassName = type ? `slds-badge_${type}` : null;
-  const badgeClassNames = classnames('slds-badge', typeClassName);
+  const typeClassName = /^(inverse|lightest)$/.test(type ?? '')
+    ? `slds-badge_${type}`
+    : null;
+  const themeClassName = /^(success|warning|error)$/.test(type ?? '')
+    ? `slds-theme_${type}`
+    : null;
+  const badgeClassNames = classnames(
+    'slds-badge',
+    typeClassName,
+    themeClassName
+  );
   return (
     <span className={badgeClassNames} {...props}>
       {label || props.children}

--- a/stories/Badge.stories.tsx
+++ b/stories/Badge.stories.tsx
@@ -30,21 +30,6 @@ export const Default: ComponentStoryObj<typeof Badge> = {
 /**
  *
  */
-export const Shade: ComponentStoryObj<typeof Badge> = {
-  args: {
-    type: 'shade',
-    children: 'Badge Label',
-  },
-  parameters: {
-    docs: {
-      storyDescription: 'Badge with type: shade',
-    },
-  },
-};
-
-/**
- *
- */
 export const Inverse: ComponentStoryObj<typeof Badge> = {
   args: {
     type: 'inverse',

--- a/stories/Badge.stories.tsx
+++ b/stories/Badge.stories.tsx
@@ -41,3 +41,63 @@ export const Inverse: ComponentStoryObj<typeof Badge> = {
     },
   },
 };
+
+/**
+ *
+ */
+export const Lightest: ComponentStoryObj<typeof Badge> = {
+  args: {
+    type: 'lightest',
+    children: 'Badge Label',
+  },
+  parameters: {
+    docs: {
+      storyDescription: 'Badge with type: lightest',
+    },
+  },
+};
+
+/**
+ *
+ */
+export const Success: ComponentStoryObj<typeof Badge> = {
+  args: {
+    type: 'success',
+    children: 'Badge Label',
+  },
+  parameters: {
+    docs: {
+      storyDescription: 'Badge with type: success',
+    },
+  },
+};
+
+/**
+ *
+ */
+export const Warning: ComponentStoryObj<typeof Badge> = {
+  args: {
+    type: 'warning',
+    children: 'Badge Label',
+  },
+  parameters: {
+    docs: {
+      storyDescription: 'Badge with type: warning',
+    },
+  },
+};
+
+/**
+ *
+ */
+export const Error: ComponentStoryObj<typeof Badge> = {
+  args: {
+    type: 'error',
+    children: 'Badge Label',
+  },
+  parameters: {
+    docs: {
+      storyDescription: 'Badge with type: error',
+    },
+  },
+};


### PR DESCRIPTION
# What I did

- update a classname
- remove unsupported `type`s
- add newly supported `type`s

# What I would like to confirm

Whether we need to add new types (`lightest`, `success` `warning`, and `error`).

# Reference

https://v1.lightningdesignsystem.com/components/badges/