### PR TITLE
Update `Text` for SLDS2

### DIFF
--- a/src/scripts/PageHeader.tsx
+++ b/src/scripts/PageHeader.tsx
@@ -31,10 +31,9 @@ export type PageHeaderDetailLabelProps = TextProps;
 export const PageHeaderDetailLabel: FC<PageHeaderDetailLabelProps> = ({
   children,
   ...props
-}) => {
-  return (
+}) =>
+  typeof children === 'string' ? (
     <Text
-      tag={typeof children !== 'string' ? 'div' : undefined}
       category='title'
       truncate
       className='slds-m-bottom_xx-small'
@@ -42,8 +41,9 @@ export const PageHeaderDetailLabel: FC<PageHeaderDetailLabelProps> = ({
     >
       {children}
     </Text>
+  ) : (
+    <>{children}</>
   );
-};
 
 /**
  *

--- a/src/scripts/PageHeader.tsx
+++ b/src/scripts/PageHeader.tsx
@@ -31,9 +31,10 @@ export type PageHeaderDetailLabelProps = TextProps;
 export const PageHeaderDetailLabel: FC<PageHeaderDetailLabelProps> = ({
   children,
   ...props
-}) =>
-  typeof children === 'string' ? (
+}) => {
+  return (
     <Text
+      tag={typeof children !== 'string' ? 'div' : undefined}
       category='title'
       truncate
       className='slds-m-bottom_xx-small'
@@ -41,9 +42,8 @@ export const PageHeaderDetailLabel: FC<PageHeaderDetailLabelProps> = ({
     >
       {children}
     </Text>
-  ) : (
-    <>{children}</>
   );
+};
 
 /**
  *

--- a/src/scripts/Text.tsx
+++ b/src/scripts/Text.tsx
@@ -29,7 +29,7 @@ export const Text: FC<TextProps> = ({
 }) => {
   const textClassNames = classnames(
     type && category ? `slds-text-${category}_${type}` : undefined,
-    category && !type ? `slds-text-${category}` : undefined,
+    category === 'title' && !type ? `slds-text-${category}` : undefined,
     align ? `slds-text-align_${align}` : undefined,
     {
       'slds-truncate': truncate,

--- a/src/scripts/Text.tsx
+++ b/src/scripts/Text.tsx
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 export type TextProps = {
   tag?: keyof ReactHTML;
   category?: 'body' | 'heading' | 'title';
-  type?: 'small' | 'regular' | 'medium' | 'large' | 'caps' | 'label';
+  type?: 'small' | 'regular' | 'medium' | 'large' | 'caps';
   align?: 'left' | 'center' | 'right';
   truncate?: boolean;
   section?: boolean;

--- a/stories/PageHeader.stories.tsx
+++ b/stories/PageHeader.stories.tsx
@@ -97,14 +97,12 @@ export const RecordHome: ComponentStoryObj<typeof PageHeader> = {
         </PageHeaderDetailItem>
         <PageHeaderDetailItem>
           <PageHeaderDetailLabel>
-            <Text tag='div' category='heading' type='label'>
-              FIELD 2 (3)
-              <DropdownButton type='icon-bare' iconSize='small' icon='down'>
-                <MenuItem>Menu Item #1</MenuItem>
-                <MenuItem>Menu Item #2</MenuItem>
-                <MenuItem>Menu Item #3</MenuItem>
-              </DropdownButton>
-            </Text>
+            FIELD 2 (3)
+            <DropdownButton type='icon-bare' iconSize='small' icon='down'>
+              <MenuItem>Menu Item #1</MenuItem>
+              <MenuItem>Menu Item #2</MenuItem>
+              <MenuItem>Menu Item #3</MenuItem>
+            </DropdownButton>
           </PageHeaderDetailLabel>
           <PageHeaderDetailBody>
             <Text category='body' type='regular' title='Multiple Values'>


### PR DESCRIPTION
# What I did

- restrict category only classname to `title`
- remove `label` from the `type` props, because it's no longer listed as a classname

# What I would like to confirm

Whether to update `PageHeaderDetailBody` without backward compatibility.

# References

- https://v1.lightningdesignsystem.com/utilities/text/
- https://v1.lightningdesignsystem.com/utilities/text/#CSS-Class-Overview