### PR TITLE
Remove React 17 support from `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,9 +100,9 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "@types/react": "^17.0.0 || ^18.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
+    "@types/react": "^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "resolutions": {
     "@types/react": "^18.2.37"


### PR DESCRIPTION
related to: https://github.com/mashmatrix/react-lightning-design-system/pull/473#discussion_r2130959945

# Why

To utilize the `useId()` hook that was introduced in React 18.

# Reference

https://react.dev/blog/2022/03/29/react-v18#useid