### PR TITLE
Remove unnecessary `textColor` props from `PicklistItem` for SLDS2

### DIFF
--- a/src/scripts/Picklist.tsx
+++ b/src/scripts/Picklist.tsx
@@ -712,12 +712,7 @@ export const PicklistItem: FC<PicklistItemProps> = ({
       >
         <span className='slds-media__figure slds-listbox__option-icon'>
           {icon ? (
-            <Icon
-              category='utility'
-              icon={icon}
-              size='x-small'
-              textColor='currentColor'
-            />
+            <Icon category='utility' icon={icon} size='x-small' />
           ) : selected ? (
             <Icon
               category='utility'
@@ -734,12 +729,7 @@ export const PicklistItem: FC<PicklistItemProps> = ({
         </span>
         {iconRight && (
           <span className='slds-media__figure slds-media__figure_reverse'>
-            <Icon
-              category='utility'
-              icon={iconRight}
-              size='x-small'
-              textColor='currentColor'
-            />
+            <Icon category='utility' icon={iconRight} size='x-small' />
           </span>
         )}
       </div>


### PR DESCRIPTION
# Summary

Just removed `textColor='currentColor'` prop from general icons in `PicklistItem`.

This is because it would be too much to apply it, as far as confirming references below.

# References

- https://v1.lightningdesignsystem.com/components/menus/#Icon-on-the-Left
    Though this example is regarding `Menus`, general icons don't have `.slds-current-color`.
- https://v1.lightningdesignsystem.com/components/picklist/
    In the spec of `Picklist`, there is no example that has general icons.
- https://v1.lightningdesignsystem.com/components/picklist/#Open-Option-Selected
    In this `Picklist` example, though check mark icons are used, general icons aren't.
    At least, the check mark icons have `.slds-current-color`.