### PR TITLE
Fix `Lookup` unselectable issue for SLDS2

### DIFF
--- a/src/scripts/Lookup.tsx
+++ b/src/scripts/Lookup.tsx
@@ -1141,6 +1141,11 @@ export const Lookup = createFC<LookupProps, { isFormElement: boolean }>(
     const dropdownElRef = useRef<HTMLDivElement | null>(null);
     const dropdownRef = useMergeRefs([dropdownElRef, dropdownRef_]);
 
+    const onScopeMenuClick = useEventCallback(() => {
+      setOpened(false);
+      onScopeMenuClick_?.();
+    });
+
     const onSelect = useEventCallback((selectedEntry: LookupEntry | null) => {
       const currValue = selectedEntry?.value ?? null;
       setValue(currValue);
@@ -1379,7 +1384,7 @@ export const Lookup = createFC<LookupProps, { isFormElement: boolean }>(
                 disabled={disabled}
                 scopeListboxId={scopeListboxId}
                 getScopeOptionId={getScopeOptionId}
-                onScopeMenuClick={onScopeMenuClick_}
+                onScopeMenuClick={onScopeMenuClick}
                 onScopeSelect={(scope) => {
                   setTargetScope(scope);
                   onScopeSelect_?.(scope);


### PR DESCRIPTION
closes: #501

# What I did

By referring to `v5.9.1`,

- apply `isFocusedInComponent()`, which covers a dropdown inside the `AutoAlign` as well, to the main selector (d3e23a7ceda2be2732df53562cbbe0ef975ab4b8)
    FYI: One of the corresponding `v5.9.1` [implementation](https://github.com/mashmatrix/react-lightning-design-system/blob/v5.9.1/src/scripts/Lookup.tsx#L739-L758)

# What I additionally did

By referring to `v5.9.1`,

- apply `isFocusedInComponent()` to the scope selector (e8787ce7c62c5b345765f64658079e27018512a8)
    FYI: One of the corresponding `v5.9.1` [implementation](https://github.com/mashmatrix/react-lightning-design-system/blob/v5.9.1/src/scripts/Lookup.tsx#L238-L251)
- enable switching between the main and the scope selector by clicking (37f0c4a25c3cf70ac8b74cdeb1f8c470c10a788a)
    FYI: One of the corresponding `v5.9.1` [implementation](https://github.com/mashmatrix/react-lightning-design-system/blob/v5.9.1/src/scripts/Lookup.tsx#L668-L673)

# What I confirmed

In the other components, `isFocusedInComponent()`s are applied similarly to `v5.9.1`, without excess or deficiency.

# Video

https://github.com/user-attachments/assets/c5a8861c-f872-4f40-b229-d5b2e929f224