### PR TITLE
Change `listHeader` and `listFooter` props to objects

### DIFF
--- a/src/scripts/Lookup.tsx
+++ b/src/scripts/Lookup.tsx
@@ -745,9 +745,17 @@ type LookupDropdownProps = {
   loading?: boolean;
   listboxId: string;
   dropdownRef: Ref<HTMLDivElement>;
-  listHeader?: JSX.Element;
+  listHeader?: {
+    onClick?: () => void;
+    icon?: string;
+    label: React.ReactNode;
+  };
   listHeaderIdSeed: string;
-  listFooter?: JSX.Element;
+  listFooter?: {
+    onClick?: () => void;
+    icon?: string;
+    label: React.ReactNode;
+  };
   listFooterIdSeed: string;
   filteredData: LookupEntry[];
   focusedValue?: string;
@@ -809,8 +817,22 @@ const LookupDropdown: FC<LookupDropdownProps> = ({
                   aria-selected='true'
                   tabIndex={0}
                   onFocus={() => onOptionFocus(listHeaderIdSeed)}
+                  onClick={listHeader.onClick}
                 >
-                  {listHeader}
+                  {listHeader.icon ? (
+                    <span className='slds-media__figure slds-listbox__option-icon'>
+                      <Icon
+                        category='utility'
+                        icon={listHeader.icon}
+                        size='x-small'
+                      />
+                    </span>
+                  ) : null}
+                  <span className='slds-media__body'>
+                    <span className='slds-listbox__option-text slds-listbox__option-text_entity'>
+                      {listHeader.label}
+                    </span>
+                  </span>
                 </div>
               </li>
             </ul>
@@ -853,8 +875,22 @@ const LookupDropdown: FC<LookupDropdownProps> = ({
                   role='option'
                   tabIndex={0}
                   onFocus={() => onOptionFocus(listFooterIdSeed)}
+                  onClick={listFooter.onClick}
                 >
-                  {listFooter}
+                  {listFooter.icon ? (
+                    <span className='slds-media__figure slds-listbox__option-icon'>
+                      <Icon
+                        category='utility'
+                        icon={listFooter.icon}
+                        size='x-small'
+                      />
+                    </span>
+                  ) : null}
+                  <span className='slds-media__body'>
+                    <span className='slds-listbox__option-text slds-listbox__option-text_entity'>
+                      {listFooter.label}
+                    </span>
+                  </span>
                 </div>
               </li>
             </ul>
@@ -935,8 +971,16 @@ export type LookupProps = {
   lookupFilter?: Bivariant<
     (entry: LookupEntry, searchText?: string, scope?: string) => boolean
   >;
-  listHeader?: JSX.Element;
-  listFooter?: JSX.Element;
+  listHeader?: {
+    onClick?: () => void;
+    icon?: string;
+    label: React.ReactNode;
+  };
+  listFooter?: {
+    onClick?: () => void;
+    icon?: string;
+    label: React.ReactNode;
+  };
   tooltip?: ReactNode;
   tooltipIcon?: string;
 

--- a/stories/Lookup.stories.tsx
+++ b/stories/Lookup.stories.tsx
@@ -4,7 +4,7 @@ import React, {
   useCallback,
   useState,
 } from 'react';
-import { Icon, Lookup, LookupEntry, LookupScope } from '../src/scripts';
+import { Lookup, LookupEntry, LookupScope } from '../src/scripts';
 import COMPANIES from './data/COMPANIES';
 import OPPORTUNITIES from './data/OPPORTUNITIES';
 import CAMPAIGNS from './data/CAMPAIGNS';
@@ -373,30 +373,14 @@ export const OpenedWithListHeaderFooter: ComponentStoryObj<typeof Lookup> = {
     opened: true,
     data: COMPANY_DATA,
     selected: null,
-    listHeader: (
-      <>
-        <span className='slds-media__figure slds-listbox__option-icon'>
-          <Icon category='utility' icon='search' size='x-small' />
-        </span>
-        <span className='slds-media__body'>
-          <span className='slds-listbox__option-text slds-listbox__option-text_entity'>
-            &quot;A&quot; in Account
-          </span>
-        </span>
-      </>
-    ),
-    listFooter: (
-      <>
-        <span className='slds-media__figure slds-listbox__option-icon'>
-          <Icon category='utility' icon='add' size='x-small' />
-        </span>
-        <span className='slds-media__body'>
-          <span className='slds-listbox__option-text slds-listbox__option-text_entity'>
-            Add new Account
-          </span>
-        </span>
-      </>
-    ),
+    listHeader: {
+      icon: 'search',
+      label: '"A" in Account',
+    },
+    listFooter: {
+      icon: 'add',
+      label: 'Add new Account',
+    },
   },
   decorators: [containerDecorator({ height: 420 })],
   parameters: {
@@ -467,30 +451,14 @@ export const DefaultOpenedWithListHeaderFooter: ComponentStoryObj<
     defaultOpened: true,
     data: COMPANY_DATA,
     selected: null,
-    listHeader: (
-      <>
-        <span className='slds-media__figure slds-listbox__option-icon'>
-          <Icon category='utility' icon='search' size='x-small' />
-        </span>
-        <span className='slds-media__body'>
-          <span className='slds-listbox__option-text slds-listbox__option-text_entity'>
-            &quot;A&quot; in Account
-          </span>
-        </span>
-      </>
-    ),
-    listFooter: (
-      <>
-        <span className='slds-media__figure slds-listbox__option-icon'>
-          <Icon category='utility' icon='add' size='x-small' />
-        </span>
-        <span className='slds-media__body'>
-          <span className='slds-listbox__option-text slds-listbox__option-text_entity'>
-            Add new Account
-          </span>
-        </span>
-      </>
-    ),
+    listHeader: {
+      icon: 'search',
+      label: '"A" in Account',
+    },
+    listFooter: {
+      icon: 'add',
+      label: 'Add new Account',
+    },
   },
   parameters: {
     docs: {


### PR DESCRIPTION
# Summary

Enabled to pass `onClick` to list header and footer, by changing their props to objects.