### PR TITLE
Support arrays of children as a `Picklist`'s selected label

### DIFF
--- a/src/scripts/Picklist.tsx
+++ b/src/scripts/Picklist.tsx
@@ -67,59 +67,57 @@ function collectOptionValues(children: unknown): PicklistValue[] {
 function findSelectedItemLabel(
   children: unknown,
   selectedValue: PicklistValue
-): React.ReactNode | null {
-  return (
-    React.Children.map(children, (child) => {
-      if (!React.isValidElement(child)) {
-        return null;
-      }
+): React.ReactNode {
+  return React.Children.map(children, (child) => {
+    if (!React.isValidElement(child)) {
+      return null;
+    }
 
-      const props = child.props;
-      const isPropsObject = typeof props === 'object' && props !== null;
+    const props = child.props;
+    const isPropsObject = typeof props === 'object' && props !== null;
 
-      if (!isPropsObject) {
-        return null;
-      }
+    if (!isPropsObject) {
+      return null;
+    }
 
-      // Recursively check children for nested PicklistItems
-      if (child.type !== PicklistItem) {
-        return !('children' in props)
-          ? null
-          : findSelectedItemLabel(props.children, selectedValue);
-      }
+    // Recursively check children for nested PicklistItems
+    if (child.type !== PicklistItem) {
+      return !('children' in props)
+        ? null
+        : findSelectedItemLabel(props.children, selectedValue);
+    }
 
-      // Check if this is specifically a PicklistItem component
-      if (!('value' in props) || props.value !== selectedValue) {
-        return null;
-      }
+    // Check if this is specifically a PicklistItem component
+    if (!('value' in props) || props.value !== selectedValue) {
+      return null;
+    }
 
-      // Skip disabled items
-      if ('disabled' in props && props.disabled === true) {
-        return null;
-      }
+    // Skip disabled items
+    if ('disabled' in props && props.disabled === true) {
+      return null;
+    }
 
-      // Safely access label and children properties with proper type checking
-      const label = 'label' in props ? props.label : undefined;
-      const itemChildren = 'children' in props ? props.children : undefined;
+    // Safely access label and children properties with proper type checking
+    const label = 'label' in props ? props.label : undefined;
+    const itemChildren = 'children' in props ? props.children : undefined;
 
-      // Simple type check for React.ReactNode values
-      const labelValue =
-        typeof label === 'string' ||
-        typeof label === 'number' ||
-        React.isValidElement(label)
-          ? label
-          : undefined;
-      const childrenValue =
-        typeof itemChildren === 'string' ||
-        typeof itemChildren === 'number' ||
-        React.isValidElement(itemChildren) ||
-        Array.isArray(itemChildren)
-          ? itemChildren
-          : undefined;
+    // Simple type check for React.ReactNode values
+    const labelValue =
+      typeof label === 'string' ||
+      typeof label === 'number' ||
+      React.isValidElement(label)
+        ? label
+        : undefined;
+    const childrenValue =
+      typeof itemChildren === 'string' ||
+      typeof itemChildren === 'number' ||
+      React.isValidElement(itemChildren) ||
+      Array.isArray(itemChildren)
+        ? itemChildren
+        : undefined;
 
-      return labelValue || childrenValue;
-    }).find((result) => result !== null) ?? null
-  );
+    return labelValue || childrenValue;
+  });
 }
 
 /**


### PR DESCRIPTION
# Summary

Enabled to show an array of children of `PicklistItem` as a selected label.

For example, the following `Picklist`
```typescript
<Picklist value='1'>
    <PicklistItem value='1'>
        Picklist Item
        {' One'}
    </PicklistItem>
</Picklist>
```
shows `Picklist Item One` instead of `Picklist Item` as a selected label.

# Behavior Before this PR

For the above example, `React.Children.map(…)` returns `['Picklist Item', ' One']` as a **flat** array.
Then, the next `.find(…)` finds `'Picklist Item'`.

As a result, only `Picklist Item` is shown as a selected label.

## Why

The doc says that `React.Children.map()` returns a **flat** array, containing **neither `null` nor `undefined`**.

https://18.react.dev/reference/react/Children#children-map-returns
> … returns a flat array consisting of the nodes you’ve returned from the fn function. The returned array will contain all nodes you returned except for null and undefined.

Therefore,
- A flattened `['Picklist Item', ' One']` is returned, because `React.Children.map()` returns a **flat** array
- [The `.find(…) ?? null` part](https://github.com/mashmatrix/react-lightning-design-system/blob/v6.0.0-beta.8/src/scripts/Picklist.tsx#L121) should have been `.filter()`, in order to support an array of children
- Moreover, neither `.find(…) ?? null` nor `.filter()` was needed, because `React.Children.map()` automatically filters `null`.