### PR TITLE
Support environments where the `CSS.escape()` doesn't exist

### DIFF
--- a/src/scripts/Lookup.tsx
+++ b/src/scripts/Lookup.tsx
@@ -274,11 +274,10 @@ const LookupScopeSelector: FC<LookupScopeSelectorProps> = ({
         getScopeOptionId(nextFocusedIndex)
       );
 
-      if (!(targetElement instanceof HTMLElement)) {
-        return;
-      }
-
-      if (!scopeDropdown.contains(targetElement)) {
+      if (
+        !(targetElement instanceof HTMLElement) ||
+        !scopeDropdown.contains(targetElement)
+      ) {
         return;
       }
 
@@ -1126,12 +1125,11 @@ export const Lookup = createFC<LookupProps, { isFormElement: boolean }>(
           getOptionId(nextFocusedValue)
         );
 
-        if (!(targetElement instanceof HTMLElement)) {
-          return;
-        }
-
         const dropdownContainer = dropdownElRef.current;
-        if (!dropdownContainer.contains(targetElement)) {
+        if (
+          !(targetElement instanceof HTMLElement) ||
+          !dropdownContainer.contains(targetElement)
+        ) {
           return;
         }
 

--- a/src/scripts/Picklist.tsx
+++ b/src/scripts/Picklist.tsx
@@ -312,12 +312,11 @@ export const Picklist: (<MultiSelect extends boolean | undefined>(
           `${optionIdPrefix}-${nextFocusedValue}`
         );
 
-        if (!(targetElement instanceof HTMLElement)) {
-          return;
-        }
-
         const dropdownContainer = dropdownElRef.current;
-        if (!dropdownContainer.contains(targetElement)) {
+        if (
+          !(targetElement instanceof HTMLElement) ||
+          !dropdownContainer.contains(targetElement)
+        ) {
           return;
         }
 


### PR DESCRIPTION
# Issue I resolved

`Picklist` and `Lookup` occur runtime error in environments where the `CSS.escape()` isn't enabled.

# Solution I applied

- use `document.getElementById()` instead of `element.querySelector()` and `CSS.escape()`

# What I confirmed

The scroll feature with keyboards described in https://github.com/mashmatrix/react-lightning-design-system/pull/481#pullrequestreview-2933977538 regarding both `Picklist` and `Lookup` hasn't regressed.