### PR TITLE
Update `react-merge-refs` to `^3.0.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "classnames": "^2.3.1",
     "dayjs": "^1.11.2",
     "keycoder": "^1.1.1",
-    "react-merge-refs": "^1.1.0",
+    "react-merge-refs": "^3.0.2",
     "react-relative-portal": "github:stomita/react-relative-portal#dist",
     "svg4everybody": "^2.1.9"
   },

--- a/src/scripts/hooks.ts
+++ b/src/scripts/hooks.ts
@@ -1,12 +1,13 @@
 import {
   Ref,
+  RefCallback,
   useCallback,
   useLayoutEffect,
   useMemo,
   useRef,
   useState,
 } from 'react';
-import mergeRefs from 'react-merge-refs';
+import { mergeRefs } from 'react-merge-refs';
 
 /**
  *
@@ -38,13 +39,26 @@ export function useEventCallback<A extends unknown[], R>(
 /**
  *
  */
-export function useMergeRefs<T>(refs: Array<Ref<T> | undefined>) {
+export function useMergeRefs<T>(
+  refs: Array<Ref<T> | undefined>
+): RefCallback<T> {
   const mrefs: Ref<T>[] = [];
   for (const ref of refs) {
     if (ref != null) {
       mrefs.push(ref);
     }
   }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  return useMemo(() => mergeRefs(mrefs), [...mrefs]);
+  return useMemo<RefCallback<T>>(
+    () => {
+      const merged = mergeRefs(mrefs);
+      return (value) => {
+        // `react-merge-refs` v3 always returns a callable; the guard
+        // narrows `Ref<T>` to `RefCallback<T>` for the type checker.
+        if (typeof merged !== 'function') return;
+        return merged(value);
+      };
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [...mrefs]
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10032,10 +10032,10 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-merge-refs@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
-  integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
+react-merge-refs@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-3.0.2.tgz#483b4e8029f89d805c4e55c8d22e9b8f77e3b58e"
+  integrity sha512-MSZAfwFfdbEvwkKWP5EI5chuLYnNUxNS7vyS0i1Jp+wtd8J4Ga2ddzhaE68aMol2Z4vCnRM/oGOo1a3V75UPlw==
 
 react-refresh@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
# Purpose

This PR is a preparatory step for supporting React 19.

`react-merge-refs` v3 adds React 19 ref-cleanup support while keeping the v1 runtime behavior on React 18 — the implementation is selected by reading `React.version` at module load.

# API changes addressed in this PR

- The default export was replaced by a named `mergeRefs` export, so the import style is updated accordingly.
- `mergeRefs()` now returns the wider `Ref<T>` type instead of `RefCallback<T>`. The local `useMergeRefs()` wrapper pins its own return to `RefCallback<T>` and wraps the library result so existing call sites continue to type-check. v3's `mergeRefs()` always returns a callable at runtime, so the wrapper is a no-op outside of the type system.

# What I confirmed

- Manually exercised the components using `useMergeRefs()` in Storybook to check that ref forwarding still behaves correctly after the wrapper rewrite. No regressions were observed.
- Read the v3 distribution source (`react-merge-refs/dist/index.js`) and confirmed that on React 18 the package selects its React 16 implementation via a `parseInt(React.version.split(".")[0], 10) >= 19` check at module load. That branch is functionally equivalent to the v1.1.0 implementation, so no behavior change is expected on the current React version.

# References

- [`react-merge-refs` README](https://github.com/gregberge/react-merge-refs)
- Tracking issue: #510