### PR TITLE
Replace `react-relative-portal` with a local implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "dayjs": "^1.11.2",
     "keycoder": "^1.1.1",
     "react-merge-refs": "^1.1.0",
-    "react-relative-portal": "github:stomita/react-relative-portal#dist",
     "svg4everybody": "^2.1.9"
   },
   "devDependencies": {

--- a/src/scripts/AutoAlign.tsx
+++ b/src/scripts/AutoAlign.tsx
@@ -10,7 +10,7 @@ import React, {
   useState,
 } from 'react';
 import classnames from 'classnames';
-import RelativePortal from 'react-relative-portal';
+import RelativePortal from './RelativePortal';
 import { ComponentSettingsContext } from './ComponentSettings';
 import { useControlledValue, useEventCallback } from './hooks';
 

--- a/src/scripts/RelativePortal.tsx
+++ b/src/scripts/RelativePortal.tsx
@@ -1,0 +1,209 @@
+import React, {
+  CSSProperties,
+  FC,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+
+const canUseDOM =
+  typeof window !== 'undefined' &&
+  typeof document !== 'undefined' &&
+  typeof document.createElement === 'function';
+
+function debounce<A extends unknown[]>(
+  fn: (...args: A) => void,
+  ms: number,
+  immediate = false
+): (...args: A) => void {
+  let pid: ReturnType<typeof setTimeout> | undefined;
+  return (...args: A) => {
+    const callNow = immediate && pid === undefined;
+    if (pid !== undefined) {
+      clearTimeout(pid);
+    }
+    pid = setTimeout(() => {
+      pid = undefined;
+      if (!immediate) {
+        fn(...args);
+      }
+    }, ms);
+    if (callNow) {
+      fn(...args);
+    }
+  };
+}
+
+let nextListenerId = 0;
+const listeners = new Map<number, () => void>();
+
+function fireListeners() {
+  for (const fn of listeners.values()) {
+    fn();
+  }
+}
+
+function subscribe(fn: () => void): () => void {
+  nextListenerId += 1;
+  const id = nextListenerId;
+  listeners.set(id, fn);
+  return () => {
+    listeners.delete(id);
+  };
+}
+
+function installDOMListeners() {
+  document.addEventListener('wheel', debounce(fireListeners, 100, true));
+  window.addEventListener('resize', debounce(fireListeners, 50, true));
+}
+
+if (canUseDOM) {
+  if (document.body) {
+    installDOMListeners();
+  } else {
+    document.addEventListener('DOMContentLoaded', installDOMListeners);
+  }
+}
+
+/**
+ * Triggers re-measurement of every mounted `RelativePortal` instance.
+ * Consumers can call this to notify portals about scroll events on
+ * inner scroll containers that the global `wheel` listener cannot
+ * observe.
+ */
+export function updateScroll() {
+  fireListeners();
+}
+
+function getPageOffset() {
+  return {
+    x: window.pageXOffset,
+    y: window.pageYOffset,
+  };
+}
+
+type MarkerPosition = {
+  top: number;
+  left: number;
+  right: number;
+};
+
+type RelativePortalProps = {
+  /** Marker element type rendered at the original tree position. */
+  component?: 'div' | 'span';
+  /** Vertical offset added to the measured marker top. */
+  top?: number;
+  /** Horizontal offset added to the measured marker left. */
+  left?: number;
+  /** Horizontal offset added to the measured marker right. */
+  right?: number;
+  /** When set, the portal stretches between the marker's left and right edges. */
+  fullWidth?: boolean;
+  /** Invoked after every re-measurement. */
+  onScroll?: () => void;
+  /** Applied to the outer portal wrapper element. */
+  className?: string;
+  /** Applied to the outer portal wrapper element. */
+  style?: CSSProperties;
+  children?: ReactNode;
+};
+
+const RelativePortal: FC<RelativePortalProps> = (props) => {
+  const {
+    component = 'span',
+    top = 0,
+    left = 0,
+    right,
+    fullWidth,
+    onScroll,
+    className,
+    style,
+    children,
+  } = props;
+
+  const markerRef = useRef<HTMLElement | null>(null);
+  const [position, setPosition] = useState<MarkerPosition>({
+    top: 0,
+    left: 0,
+    right: 0,
+  });
+  const onScrollRef = useRef(onScroll);
+  onScrollRef.current = onScroll;
+
+  const measure = useCallback(() => {
+    const el = markerRef.current;
+    if (!el) {
+      return;
+    }
+    const rect = el.getBoundingClientRect();
+    const offset = getPageOffset();
+    const next: MarkerPosition = {
+      top: offset.y + rect.top,
+      left: offset.x + rect.left,
+      right: window.innerWidth - rect.right - offset.x,
+    };
+    setPosition((current) =>
+      current.top === next.top &&
+      current.left === next.left &&
+      current.right === next.right
+        ? current
+        : next
+    );
+    onScrollRef.current?.();
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = subscribe(measure);
+    measure();
+    return unsubscribe;
+  }, [measure]);
+
+  useEffect(() => {
+    measure();
+  });
+
+  const setMarkerRef = useCallback(
+    (el: HTMLDivElement | HTMLSpanElement | null) => {
+      markerRef.current = el;
+    },
+    []
+  );
+
+  const horizontal: CSSProperties = fullWidth
+    ? { left: position.left + left, right: position.right + (right ?? 0) }
+    : right !== undefined
+    ? { right: position.right + right }
+    : { left: position.left + left };
+
+  const portalContent = (
+    <div className={className} style={style}>
+      <div
+        style={{
+          position: 'absolute',
+          top: position.top + top,
+          ...horizontal,
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+
+  if (component === 'div') {
+    return (
+      <div ref={setMarkerRef}>
+        {canUseDOM ? createPortal(portalContent, document.body) : null}
+      </div>
+    );
+  }
+  return (
+    <span ref={setMarkerRef}>
+      {canUseDOM ? createPortal(portalContent, document.body) : null}
+    </span>
+  );
+};
+
+export default RelativePortal;

--- a/src/scripts/RelativePortal.tsx
+++ b/src/scripts/RelativePortal.tsx
@@ -195,13 +195,17 @@ const RelativePortal: FC<RelativePortalProps> = (props) => {
   if (component === 'div') {
     return (
       <div ref={setMarkerRef}>
-        {canUseDOM ? createPortal(portalContent, document.body) : null}
+        {canUseDOM && document.body
+          ? createPortal(portalContent, document.body)
+          : null}
       </div>
     );
   }
   return (
     <span ref={setMarkerRef}>
-      {canUseDOM ? createPortal(portalContent, document.body) : null}
+      {canUseDOM && document.body
+        ? createPortal(portalContent, document.body)
+        : null}
     </span>
   );
 };

--- a/src/scripts/util.ts
+++ b/src/scripts/util.ts
@@ -1,4 +1,4 @@
-import { updateScroll } from 'react-relative-portal';
+import { updateScroll } from './RelativePortal';
 
 export const getToday =
   process.env.NODE_ENV === 'test'

--- a/types/react-relative-portal.d.ts
+++ b/types/react-relative-portal.d.ts
@@ -1,1 +1,0 @@
-declare module 'react-relative-portal';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4851,11 +4851,6 @@ dayjs@^1.11.2:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.10.tgz#68acea85317a6e164457d6d6947564029a6a16a0"
   integrity sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==
 
-debounce@^1.0.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
-  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
-
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -5720,11 +5715,6 @@ execa@^7.1.1:
     onetime "^6.0.0"
     signal-exit "^3.0.7"
     strip-final-newline "^3.0.0"
-
-exenv@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
-  integrity sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -9722,7 +9712,7 @@ prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.6.0, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -10033,14 +10023,6 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
-
-"react-relative-portal@github:stomita/react-relative-portal#dist":
-  version "1.3.1"
-  resolved "https://codeload.github.com/stomita/react-relative-portal/tar.gz/8d3f5bc18f518452f628598a2a1e96aad72f75dd"
-  dependencies:
-    debounce "^1.0.0"
-    exenv "^1.2.1"
-    prop-types "^15.6.0"
 
 react-shallow-renderer@^16.13.1:
   version "16.15.0"


### PR DESCRIPTION
# Purpose

This PR is a preparatory step for supporting React 19.

The `react-relative-portal` dependency relies on `ReactDOM.unstable_renderSubtreeIntoContainer()`, which has been removed in React 19. It also pulls in `PropTypes` and `componentWillUpdate()`, both of which are deprecated/removed in modern React. Bringing the component in-tree lets us drop these legacy APIs and migrate to `createPortal()` from `react-dom`.

# What this PR does

- Adds a new `src/scripts/RelativePortal.tsx` that replicates the externally observable behavior of the previous library:
    - Renders a marker element at the original tree position and mirrors its bounding rect into a portalized content node attached to `document.body`.
    - Subscribes the marker measurement to a single shared `wheel`/`resize` listener pair (debounced) so the cost is O(1) regardless of how many portals are mounted.
    - Exposes `updateScroll()` so consumers can trigger re-measurement for scroll events that the global listener cannot observe (e.g., inner scroll containers).
    - Initial render still uses zeroed coordinates until the first measurement completes, matching the previous flash behavior that callers (notably `AutoAlign`) hide via `slds-hidden`.
- Drops `PropTypes`, `defaultProps`, the unused `onOutClick` callback, and other features not consumed in this repository.
- Removes `react-relative-portal` from `dependencies` and deletes the associated `types/react-relative-portal.d.ts` ambient declaration.

# What I confirmed

- Manually exercised the components that mount portals via `AutoAlign` (`Picklist`, `DropdownButton`, `DropdownMenu`, `DateInput`, `Lookup`, `Popover`) in Storybook. Opening, closing, viewport-edge flipping, wheel scroll, and window resize all behave as before, and the portal node is mounted directly under `document.body`.
- Verified `util.updateScroll()` with a throwaway story that programmatically scrolls an inner container (which does not fire `wheel`). The dropdown stays at its previous absolute position until `updateScroll()` is called, after which it snaps back beneath the trigger — matching the contract msmx-sheet relies on for its grid scroll.

# References

- Tracking issue: #510
