### PR TITLE
Widen `react` peer dependency range to support React 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,10 +100,10 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "@types/react": "^18.3.1",
-    "@types/react-dom": "^18.3.1",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "@types/react": "^18.3.1 || ^19.0.0",
+    "@types/react-dom": "^18.3.1 || ^19.0.0",
+    "react": "^18.3.1 || ^19.0.0",
+    "react-dom": "^18.3.1 || ^19.0.0"
   },
   "resolutions": {
     "@types/react": "^18.3.1",


### PR DESCRIPTION
This would be the final PR to close #510, after merging #515(#518), #516 and #509.

# Purpose

Just widens the library's `peerDependencies` to advertise React 19 compatibility.